### PR TITLE
APP-12264: API is not callable in Docker Image

### DIFF
--- a/apps/swirl-docs/src/lib/navigation/src/pathResolver.ts
+++ b/apps/swirl-docs/src/lib/navigation/src/pathResolver.ts
@@ -5,11 +5,6 @@ export const SWIRL_COMPONENTS_PATH = path.resolve(
   `../../packages/swirl-components/src/components`
 );
 
-export const SWIRL_TOKENS_DIST_PATH = path.resolve(
-  process.cwd(),
-  `../../packages/swirl-tokens/dist`
-);
-
 export function generatePagesPath(category: string): string {
   return path.resolve(`src/pages/${category}`);
 }

--- a/apps/swirl-docs/src/pages/api/tokens/v0/utils.ts
+++ b/apps/swirl-docs/src/pages/api/tokens/v0/utils.ts
@@ -1,4 +1,3 @@
-import { SWIRL_TOKENS_DIST_PATH } from "@swirl/lib/navigation";
 import fs from "fs";
 import path from "path";
 
@@ -19,7 +18,7 @@ export const scssLight = loadFile("/scss/styles.light.scss");
 export const scssDark = loadFile("/scss/styles.dark.scss");
 
 function loadFile(filePath: string) {
-  return fs.readFileSync(SWIRL_TOKENS_DIST_PATH + filePath);
+  return fs.readFileSync("node_modules/@getflip/swirl-tokens/dist" + filePath);
 }
 
 export type TokenGroupType =


### PR DESCRIPTION
## Summary

- [Ticket](https://flipapp.myjetbrains.com/youtrack/agiles/115-52/current?issue=APP-12264)

summary:
- changed loading function to use node modules instead of monorepo package structure