### PR TITLE
Fix wrong GitHub url in storybook

### DIFF
--- a/packages/swirl-components/src/docs/02-contributions/01-get-started.stories.mdx
+++ b/packages/swirl-components/src/docs/02-contributions/01-get-started.stories.mdx
@@ -10,7 +10,7 @@ Get started by setting up your dev environment. `Node.js v16+`, `Git` and
 1. **Clone the repository**
 
 ```bash
-git clone git@github.com:flip-corp/swirl.git
+git clone git@github.com:getflip/swirl.git
 ```
 
 The Swirl Web Components Library is located at `packages/swirl-components`.


### PR DESCRIPTION
In the storybook documentation is an incorrect GitHub URL to the repository.
