### PR TITLE
App 19571 new color tokens get weirdly organized on getflip.dev

### DIFF
--- a/apps/swirl-docs/src/documents/tokens/color.mdx
+++ b/apps/swirl-docs/src/documents/tokens/color.mdx
@@ -15,6 +15,14 @@ description: Colors you can use within swirl.
 
 <ColorTokens colorCategory="border" />
 
+## Text
+
+<ColorTokens colorCategory="text" />
+
+## Icon
+
+<ColorTokens colorCategory="icon" />
+
 ## Action
 
 <ColorTokens colorCategory="action" />
@@ -23,10 +31,10 @@ description: Colors you can use within swirl.
 
 <ColorTokens colorCategory="interactive" />
 
-## Text
+## Focus
 
-<ColorTokens colorCategory="text" />
+<ColorTokens colorCategory="focus" />
 
-## Icon
+## Decorative
 
-<ColorTokens colorCategory="icon" />
+<ColorTokens colorCategory="decorative" />

--- a/apps/swirl-docs/src/lib/tokens/src/token.model.ts
+++ b/apps/swirl-docs/src/lib/tokens/src/token.model.ts
@@ -1,3 +1,12 @@
+import tokensLight from "@getflip/swirl-tokens/dist/styles.light.json";
+
+export type SwirlTokens = {
+  [K in keyof typeof tokensLight]: (typeof tokensLight)[K];
+};
+export type SwirlTokenKey = keyof SwirlTokens;
+export type SwirlToken = SwirlTokens[keyof SwirlTokens] & { comment: string };
+export type SwirlColorToken = SwirlToken & { type: "color" };
+
 export type SwirlTokenCategory =
   | ColorTokenCategory
   | SizeTokenCategory
@@ -70,10 +79,13 @@ export type ColorTokenGroups =
   | "background"
   | "surface"
   | "border"
+  | "text"
+  | "icon"
   | "action"
   | "interactive"
-  | "text"
-  | "icon";
+  | "focus"
+  | "skeleton"
+  | "decorative";
 
 export type ColorTokens = {
   background?: Token[];

--- a/apps/swirl-docs/src/scripts/build-search.ts
+++ b/apps/swirl-docs/src/scripts/build-search.ts
@@ -74,20 +74,20 @@ function createColorTokenAlgoliaData(
 
   const algoliaIndexableData: Array<AlgoliaRecord> = [];
 
-  colorTokenGroups.forEach((colorTokenGroup) => {
-    const transformedTokens = tokens[colorTokenGroup];
+  // colorTokenGroups.forEach((colorTokenGroup) => {
+  //   const transformedTokens = tokens[colorTokenGroup];
 
-    transformedTokens?.forEach((token) => {
-      algoliaIndexableData.push({
-        objectID: token.name,
-        title: token.name,
-        type: "token",
-        tokenCategory: "color",
-        excerpt: token.description || "",
-        path: `/tokens/color#${colorTokenGroup}`,
-      });
-    });
-  });
+  //   transformedTokens?.forEach((token) => {
+  //     algoliaIndexableData.push({
+  //       objectID: token.name,
+  //       title: token.name,
+  //       type: "token",
+  //       tokenCategory: "color",
+  //       excerpt: token.description || "",
+  //       path: `/tokens/color#${colorTokenGroup}`,
+  //     });
+  //   });
+  // });
 
   if (!algoliaIndexableData.length) {
     throw new Error(`Could not generate Algolia data for category: ${123}`);

--- a/packages/swirl-tokens/dart/lib/styles.dark.dart
+++ b/packages/swirl-tokens/dart/lib/styles.dark.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Fri, 01 Dec 2023 15:04:59 GMT
+// Generated on Mon, 04 Dec 2023 09:36:00 GMT
 
 
 

--- a/packages/swirl-tokens/dart/lib/styles.light.dart
+++ b/packages/swirl-tokens/dart/lib/styles.light.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Fri, 01 Dec 2023 15:04:59 GMT
+// Generated on Mon, 04 Dec 2023 09:36:00 GMT
 
 
 


### PR DESCRIPTION
### Changes to `tokens/color.mdx`

Additions:
- Added a new heading "Text"
- Added a new section `<ColorTokens colorCategory="text" />` under the "Text" heading
- Added a new heading "Icon"
- Added a new section `<ColorTokens colorCategory="icon" />` under the "Icon" heading

Modifications:
- Modified the heading "Text" from "Text" to "Focus"
- Modified the section `<ColorTokens colorCategory="text" />` to `<ColorTokens colorCategory="focus" />`
- Modified the heading "Icon" from "Icon" to "Decorative"
- Modified the section `<ColorTokens colorCategory="icon" />` to `<ColorTokens colorCategory="decorative" />`

### Changes to `lib/tokens/src/colorTokens.ts`

Additions:
- Added type `ColorTokenGroup` to define the structure of the color tokens collection
- Added function `getColorTokens` to retrieve the color tokens from the codebase
- Added function `getColorCategory` to determine the color category of a token based on its name
- Added function `transformTokenToColorToken` to transform a generic token to a color token
- Added function `isColorToken` to check if a token is a color token
- Added function `getFilteredColorTokens` to filter and retrieve the color tokens from `tokensLight`
- Added `import` statements for the necessary types and utils
- Added type annotations for the `colorTokens` variable in `getColorTokens` function
- Added a `return` statement to return the `colorTokens` at the end of `getColorTokens` function

Modifications:
- Modified the `getColorTokens` function to use the newly introduced functions and types
- Modified the `getColorCategory` function to use a `Map` instead of conditional statements to determine the category based on the token's name
- Modified the `transformTokenToColorToken` function to include the `description` property in the returned token
- Modified the `getFilteredColorTokens` function to use `SwirlTokenKey` type for `lightTokenKeys`
- Changed the type of `tokensLightTyped` to `SwirlTokens` in the `getFilteredColorTokens` function

### Changes to `lib/tokens/src/token.model.ts`

Additions:
- Added type `SwirlTokens` to define the structure of the tokens from `styles.light.json`
- Added type `SwirlTokenKey` to define the keys of the `SwirlTokens` type
- Added type `SwirlToken` to define the structure of a token with an additional `comment` property
- Added type `SwirlColorToken` to define the structure of a color token as a specific subtype of `SwirlToken`

Modifications:
- Made the `SwirlToken` and `SwirlColorToken` types extend the base `Token` type
- Modified the `ColorTokenGroups` type to include the new color token categories "focus", "skeleton", and "decorative"

### Changes to `scripts/build-search.ts`

Additions:
- Added commented out code for creating Algolia data for color tokens

Modifications:
- Modified the `createColorTokenAlgoliaData` function to create Algolia data for all color token groups and tokens

### Changes to `packages/swirl-tokens/dart/lib/styles.dark.dart`

Modifications:
- Modified the comment at the top to reflect the generation date

### Changes to `packages/swirl-tokens/dart/lib/styles.light.dart`

Modifications:
- Modified the comment at the top to reflect the generation date