### PR TITLE
fix(components): Use click event instead of focus event in swirl-date-input

### DIFF
--- a/.changeset/shy-apples-attack.md
+++ b/.changeset/shy-apples-attack.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix prefered input mode in swirl-date-input

--- a/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.spec.tsx
@@ -137,7 +137,7 @@ describe("swirl-date-input", () => {
     expect(spy.mock.calls[0][0].detail).toBe("2022-22-22");
   });
 
-  it("opens the datepicker when input gets focused and preferredInputMode is 'pick'", async () => {
+  it("opens the datepicker when input gets clicked and preferredInputMode is 'pick'", async () => {
     const page = await newSpecPage({
       components: [SwirlDateInput, SwirlPopover],
       html: `<swirl-date-input></swirl-date-input>`,
@@ -148,12 +148,12 @@ describe("swirl-date-input", () => {
 
     Object.defineProperty(popover, "open", { value: spy });
     page.root.preferredInputMode = "pick";
-    input.dispatchEvent(new FocusEvent("focus"));
+    input.dispatchEvent(new MouseEvent("click"));
 
     expect(spy).toHaveBeenCalled();
   });
 
-  it("doesn't open the datepicker when input gets focused and preferredInputMode isn't 'pick'", async () => {
+  it("doesn't open the datepicker when input gets clicked and preferredInputMode isn't 'pick'", async () => {
     const page = await newSpecPage({
       components: [SwirlDateInput, SwirlPopover],
       html: `<swirl-date-input></swirl-date-input>`,
@@ -164,7 +164,7 @@ describe("swirl-date-input", () => {
 
     Object.defineProperty(popover, "open", { value: spy });
     page.root.preferredInputMode = "input";
-    input.dispatchEvent(new FocusEvent("focus"));
+    input.dispatchEvent(new MouseEvent("click"));
 
     expect(spy).not.toHaveBeenCalled();
   });
@@ -201,7 +201,7 @@ describe("swirl-date-input", () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
-  it("keeps the focus on the input when the datepicker is opened with focus on desktop", async () => {
+  it("keeps the focus on the input when the datepicker is opened with click on desktop", async () => {
     const page = await newSpecPage({
       components: [SwirlDateInput, SwirlPopover],
       html: `<swirl-date-input></swirl-date-input>`,
@@ -213,11 +213,11 @@ describe("swirl-date-input", () => {
     page.root.preferredInputMode = "pick";
 
     input.addEventListener("focus", spy);
-    input.dispatchEvent(new FocusEvent("focus"));
+    input.dispatchEvent(new MouseEvent("click"));
 
     await new Promise((resolve) => setTimeout(resolve));
 
-    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it("lose the focus on the input when the datepicker is opened with focus on mobile", async () => {
@@ -232,10 +232,10 @@ describe("swirl-date-input", () => {
     page.root.preferredInputMode = "pick";
 
     input.addEventListener("focus", spy);
-    input.dispatchEvent(new FocusEvent("focus"));
+    input.dispatchEvent(new MouseEvent("click"));
 
     await new Promise((resolve) => setTimeout(resolve));
 
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
+++ b/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
@@ -61,7 +61,6 @@ export class SwirlDateInput {
   private inputEl: HTMLInputElement;
   private mask: Maska;
   private pickerPopover: HTMLSwirlPopoverElement;
-  private recursiveFocus = false;
 
   componentWillLoad() {
     const index = Array.from(
@@ -150,6 +149,14 @@ export class SwirlDateInput {
 
   private onClick = (event: MouseEvent) => {
     event.preventDefault();
+
+    if (this.preferredInputMode === "pick") {
+      this.pickerPopover.open(this.el);
+
+      if (!isMobileViewport()) {
+        this.focus();
+      }
+    }
   };
 
   private onMouseDown = () => {
@@ -159,19 +166,6 @@ export class SwirlDateInput {
   };
 
   private onFocus = (event: FocusEvent) => {
-    if (this.recursiveFocus) {
-      this.recursiveFocus = false;
-      return;
-    }
-
-    if (this.preferredInputMode === "pick") {
-      this.pickerPopover.open(this.el);
-
-      if (!isMobileViewport()) {
-        this.recursiveFocus = true;
-        this.focus();
-      }
-    }
     this.handleAutoSelect(event);
   };
 


### PR DESCRIPTION
## Summary

Relying on the focus event caused some problems on some mobile devices, mainly because it would still keep the focus on the input when we opened the datepicker, which would open the native keyboard on top of the datepicker...

With this approach, we lose the ability to open the datepicker when navigating with the keyboard Tab key, but in fact it was a bit of an anti-patern to open the datepicker when navigating with the keyboard, as we could still do it by hitting Enter on the trigger button.

- [Ticket](#)
- [Design](#)
- [Storybook](#)

## Review Checklist

### General

- [ ] [Changeset added](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md)
- [ ] The submitted code is organized and formatted according to our [💅 Style Guide](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-style-guide--docs).
  - [ ] The code is formatted with Prettier.
  - [ ] There are no linting errors.

### For new or updated components

https://swirl-storybook.flip-app.dev/?path=/docs/contributions-merge-publish--page

- [ ] The changes do not contain any breaking changes.
- [ ] The changes do not introduce new components that don't belong in the library (e.g. non-reusable components, highly specialized components, components including business logic)
- [ ] The component documentation is updated.
- [ ] The changes meet the [🤖 testing requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-testing--docs).
  - [ ] New features are tested.
  - [ ] In case of bug fixes, regression tests have been added.
  - [ ] All tests are 🟢.
- [ ] The changes meet the [🧏‍♀️ accessibility requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-accessibility--docs).
  - [ ] WCAG 2.1 Level A and Level AA requirements are met.
  - [ ] The Storybook a11y addon shows no errors.
  - [ ] The changes have been tested with a screen reader.
  - [ ] Keyboard controls have been tested, if applicable.
  - [ ] Components implementing form controls (inputs, buttons, selects, etc.) do not use Shadow DOM, and instead use Stencil's scoping mechanism
- [ ] The changes use our [🌈 theming concept](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-theming--docs).
  - [ ] Design tokens have been used where appropriate.
  - [ ] The component has been visually checked in combination with the "Light" and "Dark" theme.
- [ ] The changes meet our [🌍 internationalization requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-internationalization--docs).
  - [ ] No static text is used.
  - [ ] The component doesn't break with longer texts or different text wrappings.
  - [ ] Number, currency and date values can be formatted appropriately.
- [ ] The changes work in all supported browsers and viewports. See [📱 Responsive Design](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-responsive-design--docs)
