### PR TITLE
Fix SwirlModal footer padding on small devices

### DIFF
--- a/.changeset/beige-sloths-design.md
+++ b/.changeset/beige-sloths-design.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix SwirlModal footer padding on small devices

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
@@ -25,6 +25,8 @@
   --swirl-modal-max-height: 90vh;
   --swirl-modal-view-height: 100vh;
   --swirl-modal-max-width: 40rem;
+  --swirl-modal-footer-padding-small: var(--s-space-12) var(--s-space-16) var(--s-space-12) var(--s-space-16);
+  --swirl-modal-footer-padding-large: var(--s-space-16) var(--s-space-24) var(--s-space-16) var(--s-space-24);
 
   @supports (height: 100dvh) {
     --swirl-modal-max-height: 90dvh;
@@ -182,10 +184,11 @@
 
 .modal--has-custom-footer {
   & .modal__custom-footer {
-    padding-top: var(--s-space-16);
-    padding-right: var(--s-space-24);
-    padding-bottom: var(--s-space-16);
-    padding-left: var(--s-space-24);
+    padding: var(--swirl-modal-footer-padding-small);
+
+    @media (--from-tablet) {
+      padding: var(--swirl-modal-footer-padding-large);
+    }
   }
 }
 
@@ -417,12 +420,13 @@
 
 .modal__controls {
   display: flex;
-  padding-top: var(--s-space-16);
-  padding-right: var(--s-space-24);
-  padding-bottom: var(--s-space-16);
-  padding-left: var(--s-space-24);
+  padding: var(--swirl-modal-footer-padding-small);
   flex-shrink: 0;
   justify-content: flex-end;
+
+  @media (--from-tablet) {
+    padding: var(--swirl-modal-footer-padding-large);
+  }
 }
 
 @keyframes modal-scale-in {


### PR DESCRIPTION
## Summary

- [Ticket](#)
- [Design](#)
- [Storybook](#)

The custom_footer and controls padding is differing from the Figma files, and therefore not aligned with the most recent design.

| Before | After |
|--------|--------|
| <img width="422" alt="Screenshot 2024-05-17 at 14 31 24" src="https://github.com/getflip/swirl/assets/2084270/fc7ed577-0e9f-4da5-a329-da850117a55f"> | <img width="403" alt="Screenshot 2024-05-17 at 14 37 00" src="https://github.com/getflip/swirl/assets/2084270/8c10b6a4-7888-47be-a913-6f925d2e4c07"> |



## Review Checklist

### General

- [x] [Changeset added](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md)
- [ ] The submitted code is organized and formatted according to our [💅 Style Guide](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-style-guide--docs).
  - [ ] The code is formatted with Prettier.
  - [ ] There are no linting errors.

### For new or updated components

https://swirl-storybook.flip-app.dev/?path=/docs/contributions-merge-publish--page

- [ ] The changes do not contain any breaking changes.
- [ ] The changes do not introduce new components that don't belong in the library (e.g. non-reusable components, highly specialized components, components including business logic)
- [ ] The component documentation is updated.
- [ ] The changes meet the [🤖 testing requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-testing--docs).
  - [ ] New features are tested.
  - [ ] In case of bug fixes, regression tests have been added.
  - [ ] All tests are 🟢.
- [ ] The changes meet the [🧏‍♀️ accessibility requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-accessibility--docs).
  - [ ] WCAG 2.1 Level A and Level AA requirements are met.
  - [ ] The Storybook a11y addon shows no errors.
  - [ ] The changes have been tested with a screen reader.
  - [ ] Keyboard controls have been tested, if applicable.
  - [ ] Components implementing form controls (inputs, buttons, selects, etc.) do not use Shadow DOM, and instead use Stencil's scoping mechanism
- [ ] The changes use our [🌈 theming concept](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-theming--docs).
  - [ ] Design tokens have been used where appropriate.
  - [ ] The component has been visually checked in combination with the "Light" and "Dark" theme.
- [ ] The changes meet our [🌍 internationalization requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-internationalization--docs).
  - [ ] No static text is used.
  - [ ] The component doesn't break with longer texts or different text wrappings.
  - [ ] Number, currency and date values can be formatted appropriately.
- [ ] The changes work in all supported browsers and viewports. See [📱 Responsive Design](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-responsive-design--docs)
