### PR TITLE
Fix swirl-file-viewer-pdf current page number

### DIFF
--- a/.changeset/khaki-ghosts-film.md
+++ b/.changeset/khaki-ghosts-film.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix swirl-file-viewer-pdf current page number

--- a/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-pdf/swirl-file-viewer-pdf.tsx
+++ b/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-pdf/swirl-file-viewer-pdf.tsx
@@ -346,16 +346,16 @@ export class SwirlFileViewerPdf {
         : pages
             .filter((page) => getVisibleHeight(page, this.scrollContainer) > 0)
             .map((page) => +page.dataset.pageNumber);
+    }
 
-      const visiblePagesDidNotChanged =
-        this.visiblePages.length === visiblePages.length &&
-        this.visiblePages.every((pageNumber) =>
-          visiblePages.includes(pageNumber)
-        );
+    const visiblePagesDidNotChanged =
+      this.visiblePages.length === visiblePages.length &&
+      this.visiblePages.every((pageNumber) =>
+        visiblePages.includes(pageNumber)
+      );
 
-      if (visiblePagesDidNotChanged) {
-        return;
-      }
+    if (visiblePagesDidNotChanged) {
+      return;
     }
 
     this.visiblePages = visiblePages;

--- a/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-pdf/swirl-file-viewer-pdf.tsx
+++ b/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-pdf/swirl-file-viewer-pdf.tsx
@@ -51,11 +51,11 @@ export class SwirlFileViewerPdf {
   @Prop() workerSrc?: string = "/pdfjs/pdf.worker.min.js";
   @Prop() zoom?: SwirlFileViewerPdfZoom = 1;
 
+  @State() currentPage: number = null;
   @State() doc: PDFDocumentProxy;
   @State() error: boolean;
   @State() loading: boolean = true;
   @State() renderedPages: number[] = [];
-  @State() scrolledDown: boolean = false;
   @State() singlePageModePage: number = 1;
   @State() visiblePages: number[] = [];
 
@@ -80,7 +80,6 @@ export class SwirlFileViewerPdf {
 
   componentDidRender() {
     this.updateVisiblePages();
-    this.determineScrollStatus();
   }
 
   disconnectedCallback() {
@@ -92,16 +91,12 @@ export class SwirlFileViewerPdf {
     this.visiblePages = [];
     this.renderedPages = [];
     await this.updateVisiblePages();
-
-    this.determineScrollStatus();
   }
 
   @Watch("file")
   async watchProps() {
     await this.getPages();
     await this.updateVisiblePages();
-
-    this.determineScrollStatus();
   }
 
   @Watch("viewMode")
@@ -110,8 +105,6 @@ export class SwirlFileViewerPdf {
       this.visiblePages = [];
       this.renderedPages = [];
       await this.updateVisiblePages();
-
-      this.determineScrollStatus();
     });
   }
 
@@ -123,8 +116,6 @@ export class SwirlFileViewerPdf {
       this.visiblePages = [];
       this.renderedPages = [];
       await this.updateVisiblePages();
-
-      this.determineScrollStatus();
     });
   }
 
@@ -337,15 +328,31 @@ export class SwirlFileViewerPdf {
     );
 
     let visiblePages: number[] = [];
+    let currentPage = null;
 
     if (this.singlePageMode) {
       visiblePages = [this.singlePageModePage];
+      currentPage = this.singlePageModePage;
+    } else if (forPrint) {
+      visiblePages = pages.map((page) => +page.dataset.pageNumber);
     } else {
-      visiblePages = forPrint
-        ? pages.map((page) => +page.dataset.pageNumber)
-        : pages
-            .filter((page) => getVisibleHeight(page, this.scrollContainer) > 0)
-            .map((page) => +page.dataset.pageNumber);
+      const visiblePagesVisibleHeight = pages
+        .map((page) => ({
+          pageNumber: +page.dataset.pageNumber,
+          visibleHeight: getVisibleHeight(page, this.scrollContainer),
+        }))
+        .filter(({ visibleHeight }) => visibleHeight > 0);
+
+      visiblePages = visiblePagesVisibleHeight.map((page) => page.pageNumber);
+
+      if (visiblePagesVisibleHeight.length > 0) {
+        const firstMostVisiblePage = visiblePagesVisibleHeight.reduce(
+          (previous, current) =>
+            current.visibleHeight > previous.visibleHeight ? current : previous
+        );
+
+        currentPage = firstMostVisiblePage.pageNumber;
+      }
     }
 
     const visiblePagesDidNotChanged =
@@ -354,11 +361,12 @@ export class SwirlFileViewerPdf {
         visiblePages.includes(pageNumber)
       );
 
-    if (visiblePagesDidNotChanged) {
+    if (visiblePagesDidNotChanged && this.currentPage === currentPage) {
       return;
     }
 
     this.visiblePages = visiblePages;
+    this.currentPage = currentPage;
 
     await this.renderVisiblePages(forPrint);
 
@@ -466,17 +474,6 @@ export class SwirlFileViewerPdf {
       this.recentScrollPosition.x * this.scrollContainer?.scrollWidth;
   }
 
-  private determineScrollStatus = () => {
-    const scrolledDown =
-      Math.ceil(
-        this.scrollContainer?.scrollTop + this.scrollContainer?.offsetHeight
-      ) >= this.scrollContainer?.scrollHeight;
-
-    if (scrolledDown !== this.scrolledDown) {
-      this.scrolledDown = scrolledDown;
-    }
-  };
-
   private storeRecentScrollPosition = () => {
     this.recentScrollPosition = {
       x:
@@ -496,18 +493,12 @@ export class SwirlFileViewerPdf {
 
   private onScroll = debounce(() => {
     this.updateVisiblePages();
-    this.determineScrollStatus();
     this.storeRecentScrollPosition();
   }, 60);
 
   render() {
     const showPagination =
       !this.error && !this.loading && this.visiblePages.length > 0;
-
-    const currentPage =
-      this.scrolledDown && !this.singlePageMode
-        ? this.pages.length - 1
-        : this.visiblePages[0];
 
     const showSpinner = this.loading;
 
@@ -578,7 +569,8 @@ export class SwirlFileViewerPdf {
             id="pagination"
             part="file-viewer-pdf__pagination"
           >
-            <span aria-current="page">{currentPage}</span> / {this.doc.numPages}
+            <span aria-current="page">{this.currentPage}</span> /{" "}
+            {this.doc.numPages}
           </span>
         )}
         {showSpinner && (


### PR DESCRIPTION
## Summary

- [BSW-118: SwirlFileViewer shows wrong page number](https://linear.app/flip/issue/BSW-118/swirlfileviewer-shows-wrong-page-number)

To solve the problem, I changed the strategy that defines the current page.
Previously, we defined the current page as the first visible page and, when the user scrolled down to the end of the file, we defined the current page as the last one (actually, that was the bug, because we were defining the second to last page and not the last one).
The new strategy defines the current page as the first most visible page, so that when we have two visible pages, the current one is the most visible, which is the standard behaviour in other file viewers, such as Chrome.
The only edge case I've found is when we have small pages (height) and we can have two full pages visible at the end of the viewer, it will consider the current one as the first one. From what I've found, this is also what Chrome is considering, so I wouldn't consider it a problem.

If you have any question reach out!

## Review Checklist

### General

- [x] [Changeset added](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md)
- [x] The submitted code is organized and formatted according to our [💅 Style Guide](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-style-guide--docs).
  - [ ] The code is formatted with Prettier.
  - [ ] There are no linting errors.

### For new or updated components

https://swirl-storybook.flip-app.dev/?path=/docs/contributions-merge-publish--page

- [x] The changes do not contain any breaking changes.
- [x] The changes do not introduce new components that don't belong in the library (e.g. non-reusable components, highly specialized components, components including business logic)
- [x] The component documentation is updated.
- [x] The changes meet the [🤖 testing requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-testing--docs).
  - [ ] New features are tested.
  - [ ] In case of bug fixes, regression tests have been added.
  - [ ] All tests are 🟢.
- [ ] The changes meet the [🧏‍♀️ accessibility requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-accessibility--docs).
  - [ ] WCAG 2.1 Level A and Level AA requirements are met.
  - [ ] The Storybook a11y addon shows no errors.
  - [ ] The changes have been tested with a screen reader.
  - [ ] Keyboard controls have been tested, if applicable.
  - [ ] Components implementing form controls (inputs, buttons, selects, etc.) do not use Shadow DOM, and instead use Stencil's scoping mechanism
- [ ] The changes use our [🌈 theming concept](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-theming--docs).
  - [ ] Design tokens have been used where appropriate.
  - [ ] The component has been visually checked in combination with the "Light" and "Dark" theme.
- [ ] The changes meet our [🌍 internationalization requirements](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-internationalization--docs).
  - [ ] No static text is used.
  - [ ] The component doesn't break with longer texts or different text wrappings.
  - [ ] Number, currency and date values can be formatted appropriately.
- [ ] The changes work in all supported browsers and viewports. See [📱 Responsive Design](https://swirl-storybook.flip-app.dev/?path=/docs/requirements-responsive-design--docs)
