### PR TITLE
Fix date input value update

### DIFF
--- a/.changeset/sweet-dolls-jam.md
+++ b/.changeset/sweet-dolls-jam.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Fix value update issue in the swirl-date-input component

--- a/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
+++ b/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
@@ -99,6 +99,13 @@ export class SwirlDateInput {
     this.setupMask();
   }
 
+  @Watch("value")
+  watchValue(newValue: string, oldValue: string) {
+    if (newValue !== oldValue) {
+      this.valueChange.emit(newValue);
+    }
+  }
+
   private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
     this.updateIconSize(event.matches);
   };

--- a/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
+++ b/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
@@ -125,7 +125,6 @@ export class SwirlDateInput {
 
     if (value === "") {
       this.value = undefined;
-      this.valueChange.emit(undefined);
     }
 
     const newDate = parse(value, this.format, new Date());
@@ -149,7 +148,6 @@ export class SwirlDateInput {
     const newValue = format(newDate, internalDateFormat);
 
     this.value = newValue;
-    this.valueChange.emit(newValue);
   };
 
   private onInput = (event: InputEvent) => {
@@ -192,7 +190,6 @@ export class SwirlDateInput {
     const newValue = format(newDateValue, internalDateFormat);
 
     this.value = newValue;
-    this.valueChange.emit(newValue);
 
     this.setReadOnly(true);
     this.pickerPopover.close();


### PR DESCRIPTION
Date input did not emit `valueChange` event when the value was changed programatically, causing some issues.
Additionally removed the direct `valueChange` emits as the new watcher should handle those whenever a value changes.