### PR TITLE
getflip.dev - Fix display of nested arrays

### DIFF
--- a/apps/swirl-docs/src/components/Documentation/EndpointDescription/Parameter.tsx
+++ b/apps/swirl-docs/src/components/Documentation/EndpointDescription/Parameter.tsx
@@ -1,7 +1,5 @@
-import { SwirlIconAdd, SwirlIconRemove } from "@getflip/swirl-components-react";
 import classNames from "classnames";
-import { AnimatePresence, motion } from "framer-motion";
-import { ReactNode, useState } from "react";
+import { ReactNode } from "react";
 import { Tag } from "../../Tags";
 import { DocumentationMarkdown } from "../DocumentationMarkdown";
 import {
@@ -10,6 +8,7 @@ import {
   isValidStatusCode,
 } from "../HttpStatusCodeMapper";
 import { isProdDeployment } from "@swirl/lib/env";
+import { Expandable } from "../Expandable";
 
 interface ParameterProps {
   children?: ReactNode;
@@ -19,6 +18,7 @@ interface ParameterProps {
   hidden?: boolean;
   description?: string;
   enumValues?: string[];
+  array?: boolean;
 }
 
 export function Parameter({
@@ -29,13 +29,8 @@ export function Parameter({
   required,
   hidden,
   enumValues,
+  array,
 }: ParameterProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-
-  function toggle() {
-    setIsExpanded((expanded) => !expanded);
-  }
-
   if (isProdDeployment && hidden) {
     return null;
   }
@@ -63,7 +58,7 @@ export function Parameter({
           {isValidStatusCode(name) &&
             `${getStatusText(Number(name) as HttpStatusCode)}`}
         </code>
-        {type && <Tag content={type} />}
+        {type && <Tag content={type + (array ? "[]" : "")} />}
         {required && <Tag content="required" scheme="critical" />}
         {hidden && <Tag content="hidden for public" scheme="info" /> }
       </div>
@@ -73,66 +68,37 @@ export function Parameter({
         </DocumentationMarkdown>
       )}
       {enumValues?.length && (
-        <div className="mt-space-8">
-          <div
-            className={classNames(
-              "border-border-1 border-border-default p-4",
-              "first-of-type:rounded-t-border-radius-sm last-of-type:rounded-b-border-radius-sm",
-              "border-b-0 last-of-type:border-border-1",
-              "only:rounded-border-radius-sm only:border-border-1"
-            )}
-          >
+        <Expandable>
+          <div className="mt-space-8">
+            <div
+              className={classNames(
+                "border-border-1 border-border-default p-4",
+                "first-of-type:rounded-t-border-radius-sm last-of-type:rounded-b-border-radius-sm",
+                "border-b-0 last-of-type:border-border-1",
+                "only:rounded-border-radius-sm only:border-border-1"
+              )}
+            >
             <span className="font-font-weight-medium text-font-size-sm text-text-subdued">
               Possible enum values
             </span>
+            </div>
+            <div
+              className={classNames(
+                "flex flex-wrap gap-y-space-8",
+                "border-border-1 border-border-default p-4",
+                "first-of-type:rounded-t-border-radius-sm last-of-type:rounded-b-border-radius-sm",
+                "border-b-0 last-of-type:border-border-1",
+                "only:rounded-border-radius-sm only:border-border-1"
+              )}
+            >
+              {enumValues.map((value) => (
+                <Tag key={value} content={value} />
+              ))}
+            </div>
           </div>
-          <div
-            className={classNames(
-              "flex flex-wrap gap-y-space-8",
-              "border-border-1 border-border-default p-4",
-              "first-of-type:rounded-t-border-radius-sm last-of-type:rounded-b-border-radius-sm",
-              "border-b-0 last-of-type:border-border-1",
-              "only:rounded-border-radius-sm only:border-border-1"
-            )}
-          >
-            {enumValues.map((value) => (
-              <Tag key={value} content={value} />
-            ))}
-          </div>
-        </div>
+        </Expandable>
       )}
-      {children && (
-        <div className="mt-space-8 empty:mt-0">
-          <button
-            className="inline-flex items-center gap-space-4 font-medium text-font-size-sm text-interactive-primary-default"
-            onClick={toggle}
-            type="button"
-          >
-            {!isExpanded && (
-              <>
-                <SwirlIconAdd size={20} /> Expand
-              </>
-            )}
-            {isExpanded && (
-              <>
-                <SwirlIconRemove size={20} /> Collapse
-              </>
-            )}
-          </button>
-          <AnimatePresence>
-            {isExpanded && (
-              <motion.div
-                initial={{ height: 0, opacity: 0, marginTop: 0 }}
-                animate={{ height: "auto", opacity: 1, marginTop: 16 }}
-                exit={{ height: 0, opacity: 0, marginTop: 0 }}
-                style={{ originY: 0, overflow: "hidden" }}
-              >
-                {children}
-              </motion.div>
-            )}
-          </AnimatePresence>
-        </div>
-      )}
+      {children && <Expandable>{children}</Expandable>}
     </div>
   );
 }

--- a/apps/swirl-docs/src/components/Documentation/EndpointDescription/ParameterFactory.tsx
+++ b/apps/swirl-docs/src/components/Documentation/EndpointDescription/ParameterFactory.tsx
@@ -23,8 +23,6 @@ export class EndpointParameterFactory {
 
   getRenderer(type: string): ParameterRenderer {
     switch (type) {
-      case "array":
-        return new ArrayParameterRenderer();
       case "object":
         return new ObjectParameterRenderer();
       case "boolean":
@@ -58,6 +56,7 @@ class ObjectParameterRenderer implements ParameterRenderer {
         type={parameter.type}
         description={parameter.description}
         hidden={parameter.hidden}
+        array={parameter.array}
         required={
           parameter.required || schema?.required?.includes(parameter.name)
         }
@@ -85,74 +84,12 @@ class PrimitiveParameterRenderer implements ParameterRenderer {
         type={parameter.type}
         description={parameter.description}
         hidden={parameter.hidden}
+        array={parameter.array}
+        enumValues={parameter.enum}
         required={
           parameter.required || schema?.required?.includes(parameter.name)
         }
       />
-    );
-  }
-}
-
-class ArrayParameterRenderer implements ParameterRenderer {
-  render(
-    parameter: OperationSchemaObject,
-    schema?: OpenAPIV3_1.BaseSchemaObject
-  ) {
-    if (parameter.items?.type === "object") {
-      return (
-        <Parameter
-          key={`parameter.name${parameter.name}`}
-          name={parameter.name}
-          type={parameter.type}
-          description={parameter.description}
-          hidden={parameter.hidden}
-          required={
-            parameter.required || schema?.required?.includes(parameter.name)
-          }
-        >
-          {Object.keys(parameter.items?.properties).map((name) => {
-            const isRequired = parameter.items?.required
-              ? parameter.items?.required.includes(name)
-              : false;
-            return (
-              <Parameter
-                key={`parameter.name${parameter.name}${name}`}
-                name={name}
-                type={parameter.items?.properties[name].type}
-                description={parameter.items?.properties[name].description}
-                hidden={parameter.hidden}
-                required={isRequired}
-              />
-            );
-          })}
-        </Parameter>
-      );
-    }
-
-    return (
-      <Parameter
-        key={`parameter.name${parameter.name}`}
-        name={parameter.name}
-        type={parameter.type}
-        description={parameter.description}
-        hidden={parameter.hidden}
-        required={
-          parameter.required || schema?.required?.includes(parameter.name)
-        }
-      >
-        {parameter.items?.type === "string" && (
-          <Parameter
-            key={`string.${parameter.name}`}
-            name={parameter.items.format ? parameter.items.format : "enum"}
-            type={parameter.items?.type}
-            enumValues={parameter.items.enum}
-            hidden={parameter.hidden}
-            description={
-              parameter.items.enum ? parameter.items.enum.join(", ") : "null"
-            }
-          />
-        )}
-      </Parameter>
     );
   }
 }

--- a/apps/swirl-docs/src/components/Documentation/Expandable.tsx
+++ b/apps/swirl-docs/src/components/Documentation/Expandable.tsx
@@ -1,0 +1,48 @@
+import { ReactNode, useState } from "react";
+import { SwirlIconAdd, SwirlIconRemove } from "@getflip/swirl-components-react";
+import { AnimatePresence, motion } from "framer-motion";
+
+interface ExpandableProps {
+  children: ReactNode;
+}
+
+export function Expandable({ children }: ExpandableProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  function toggle() {
+    setIsExpanded((expanded) => !expanded);
+  }
+
+  return (
+    <div className="mt-space-8 empty:mt-0">
+      <button
+        className="inline-flex items-center gap-space-4 font-medium text-font-size-sm text-interactive-primary-default"
+        onClick={toggle}
+        type="button"
+      >
+        {!isExpanded && (
+          <>
+            <SwirlIconAdd size={20}/> Expand
+          </>
+        )}
+        {isExpanded && (
+          <>
+            <SwirlIconRemove size={20}/> Collapse
+          </>
+        )}
+      </button>
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{height: 0, opacity: 0, marginTop: 0}}
+            animate={{height: "auto", opacity: 1, marginTop: 16}}
+            exit={{height: 0, opacity: 0, marginTop: 0}}
+            style={{originY: 0, overflow: "hidden"}}
+          >
+            {children}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/apps/swirl-docs/src/lib/docs/src/docs.model.ts
+++ b/apps/swirl-docs/src/lib/docs/src/docs.model.ts
@@ -90,15 +90,14 @@ export type ApiDoc = {
 
 export type OperationSchemaObject = {
   name: string;
-  type:
-    | OpenAPIV3_1.ArraySchemaObjectType
-    | OpenAPIV3_1.NonArraySchemaObjectType;
+  type: OpenAPIV3_1.NonArraySchemaObjectType;
   description: string;
   required: boolean;
   hidden: boolean;
+  array: boolean;
   properties?: OperationSchemaObject[];
-  items?: any;
   statusCode?: string;
+  enum?: string[];
 };
 
 export type OperationParamType =


### PR DESCRIPTION
## Summary

Ticket: ACT-632

This is a follow-up to #844. It turned out that the rendering of properties nested in arrays was not fully implemented, causing a number of rendering problems, one of them us not being able to hide fields that are going to be deprecated.

This PR fixes this and alongside a number of other rendering issues with properties nested in arrays.