### PR TITLE
Adjust the swirl-modal for post preview

### DIFF
--- a/.changeset/chilly-camels-explode.md
+++ b/.changeset/chilly-camels-explode.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Fix swirl-image-grid overlays and add additional swirl-modal customizations

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -1601,6 +1601,8 @@ export namespace Components {
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
+        "hideSecondaryContent"?: boolean;
+        "hideSecondaryContentBorders"?: boolean;
         "label": string;
         "maxHeight"?: string;
         "maxWidth"?: string;
@@ -1610,7 +1612,12 @@ export namespace Components {
         "open": () => Promise<void>;
         "padded"?: boolean;
         "primaryActionLabel"?: string;
+        "primaryContentFlex"?: string;
+        "primaryContentMaxWidth"?: string;
+        "removeSecondaryContentPadding"?: boolean;
         "secondaryActionLabel"?: string;
+        "secondaryContentFlex"?: string;
+        "secondaryContentMaxWidth"?: string;
         "variant"?: SwirlModalVariant;
     }
     interface SwirlOptionList {
@@ -7064,6 +7071,8 @@ declare namespace LocalJSX {
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
+        "hideSecondaryContent"?: boolean;
+        "hideSecondaryContentBorders"?: boolean;
         "label": string;
         "maxHeight"?: string;
         "maxWidth"?: string;
@@ -7074,7 +7083,12 @@ declare namespace LocalJSX {
         "onSecondaryAction"?: (event: SwirlModalCustomEvent<MouseEvent>) => void;
         "padded"?: boolean;
         "primaryActionLabel"?: string;
+        "primaryContentFlex"?: string;
+        "primaryContentMaxWidth"?: string;
+        "removeSecondaryContentPadding"?: boolean;
         "secondaryActionLabel"?: string;
+        "secondaryContentFlex"?: string;
+        "secondaryContentMaxWidth"?: string;
         "variant"?: SwirlModalVariant;
     }
     interface SwirlOptionList {

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -40,7 +40,7 @@ import { SwirlInlineStatusIntent, SwirlInlineStatusSize } from "./components/swi
 import { SwirlLinkColor, SwirlLinkTarget } from "./components/swirl-link/swirl-link";
 import { SwirlMenuVariant } from "./components/swirl-menu/swirl-menu";
 import { SwirlActionListItemIntent as SwirlActionListItemIntent1 } from "./components/swirl-action-list-item/swirl-action-list-item";
-import { SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
+import { SwirlModalPadding, SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
 import { SwirlOptionListItemContext, SwirlOptionListItemRole } from "./components/swirl-option-list-item/swirl-option-list-item";
 import { SwirlPaginationVariant } from "./components/swirl-pagination/swirl-pagination";
 import { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover";
@@ -107,7 +107,7 @@ export { SwirlInlineStatusIntent, SwirlInlineStatusSize } from "./components/swi
 export { SwirlLinkColor, SwirlLinkTarget } from "./components/swirl-link/swirl-link";
 export { SwirlMenuVariant } from "./components/swirl-menu/swirl-menu";
 export { SwirlActionListItemIntent as SwirlActionListItemIntent1 } from "./components/swirl-action-list-item/swirl-action-list-item";
-export { SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
+export { SwirlModalPadding, SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
 export { SwirlOptionListItemContext, SwirlOptionListItemRole } from "./components/swirl-option-list-item/swirl-option-list-item";
 export { SwirlPaginationVariant } from "./components/swirl-pagination/swirl-pagination";
 export { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover";
@@ -1614,10 +1614,14 @@ export namespace Components {
         "primaryActionLabel"?: string;
         "primaryContentFlex"?: string;
         "primaryContentMaxWidth"?: string;
-        "removeSecondaryContentPadding"?: boolean;
         "secondaryActionLabel"?: string;
         "secondaryContentFlex"?: string;
         "secondaryContentMaxWidth"?: string;
+        "secondaryContentPadding"?: SwirlModalPadding;
+        "secondaryContentPaddingBlockEnd"?: SwirlModalPadding;
+        "secondaryContentPaddingBlockStart"?: SwirlModalPadding;
+        "secondaryContentPaddingInlineEnd"?: SwirlModalPadding;
+        "secondaryContentPaddingInlineStart"?: SwirlModalPadding;
         "variant"?: SwirlModalVariant;
     }
     interface SwirlOptionList {
@@ -7085,10 +7089,14 @@ declare namespace LocalJSX {
         "primaryActionLabel"?: string;
         "primaryContentFlex"?: string;
         "primaryContentMaxWidth"?: string;
-        "removeSecondaryContentPadding"?: boolean;
         "secondaryActionLabel"?: string;
         "secondaryContentFlex"?: string;
         "secondaryContentMaxWidth"?: string;
+        "secondaryContentPadding"?: SwirlModalPadding;
+        "secondaryContentPaddingBlockEnd"?: SwirlModalPadding;
+        "secondaryContentPaddingBlockStart"?: SwirlModalPadding;
+        "secondaryContentPaddingInlineEnd"?: SwirlModalPadding;
+        "secondaryContentPaddingInlineStart"?: SwirlModalPadding;
         "variant"?: SwirlModalVariant;
     }
     interface SwirlOptionList {

--- a/packages/swirl-components/src/components/swirl-image-grid/swirl-image-grid.tsx
+++ b/packages/swirl-components/src/components/swirl-image-grid/swirl-image-grid.tsx
@@ -23,6 +23,10 @@ export class SwirlImageGrid {
       this.el.children
     ) as HTMLSwirlImageGridItemElement[];
 
+    this.items.forEach((item) => {
+      item.overlay = undefined;
+    });
+
     if (this.items.length > 4) {
       this.items[3].overlay = `+${this.items.length - 4}`;
     }

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
@@ -433,12 +433,6 @@
   }
 }
 
-.modal--remove-secondary-content-padding {
-  & .modal__secondary-content {
-    padding: 0;
-  }
-}
-
 @keyframes modal-scale-in {
   from {
     transform: scale(0);

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
@@ -25,8 +25,10 @@
   --swirl-modal-max-height: 90vh;
   --swirl-modal-view-height: 100vh;
   --swirl-modal-max-width: 40rem;
-  --swirl-modal-footer-padding-small: var(--s-space-12) var(--s-space-16) var(--s-space-12) var(--s-space-16);
-  --swirl-modal-footer-padding-large: var(--s-space-16) var(--s-space-24) var(--s-space-16) var(--s-space-24);
+  --swirl-modal-footer-padding-small: var(--s-space-12) var(--s-space-16)
+    var(--s-space-12) var(--s-space-16);
+  --swirl-modal-footer-padding-large: var(--s-space-16) var(--s-space-24)
+    var(--s-space-16) var(--s-space-24);
 
   @supports (height: 100dvh) {
     --swirl-modal-max-height: 90dvh;
@@ -207,21 +209,23 @@
     max-width: 64rem;
   }
 
-  &:not(.modal--has-header-tools) .modal__header {
+  &:not(.modal--has-header-tools):not(.modal--hide-secondary-content-borders)
+    .modal__header {
     border-bottom-color: var(--s-border-default);
   }
 
-  &.modal--has-header-tools .modal__header-tools {
+  &.modal--has-header-tools:not(.modal--hide-secondary-content-borders)
+    .modal__header-tools {
     border-bottom-color: var(--s-border-default);
   }
 
-  &.modal--has-custom-footer {
+  &.modal--has-custom-footer:not(.modal--hide-secondary-content-borders) {
     & .modal__custom-footer {
       border-top: var(--s-border-width-default) solid var(--s-border-default);
     }
   }
 
-  &:not(.modal--has-custom-footer) {
+  &:not(.modal--has-custom-footer):not(.modal--hide-secondary-content-borders) {
     & .modal__controls {
       border-top: var(--s-border-width-default) solid var(--s-border-default);
     }
@@ -426,6 +430,12 @@
 
   @media (--from-tablet) {
     padding: var(--swirl-modal-footer-padding-large);
+  }
+}
+
+.modal--remove-secondary-content-padding {
+  & .modal__secondary-content {
+    padding: 0;
   }
 }
 

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
@@ -16,6 +16,17 @@ import * as focusTrap from "focus-trap";
 
 export type SwirlModalVariant = "default" | "drawer";
 
+export type SwirlModalPadding =
+  | "0"
+  | "2"
+  | "4"
+  | "8"
+  | "12"
+  | "16"
+  | "20"
+  | "24"
+  | "32";
+
 /**
  * @slot slot - Modal contents
  * @slot secondary-content - Secondary content
@@ -49,7 +60,11 @@ export class SwirlModal {
   @Prop() primaryContentFlex?: string;
   @Prop() secondaryContentFlex?: string;
   @Prop() hideSecondaryContentBorders?: boolean;
-  @Prop() removeSecondaryContentPadding?: boolean;
+  @Prop() secondaryContentPadding?: SwirlModalPadding;
+  @Prop() secondaryContentPaddingBlockEnd?: SwirlModalPadding;
+  @Prop() secondaryContentPaddingBlockStart?: SwirlModalPadding;
+  @Prop() secondaryContentPaddingInlineEnd?: SwirlModalPadding;
+  @Prop() secondaryContentPaddingInlineStart?: SwirlModalPadding;
 
   @Event() modalClose: EventEmitter<void>;
   @Event() modalOpen: EventEmitter<void>;
@@ -250,8 +265,6 @@ export class SwirlModal {
       "modal--scrolled": this.scrolled,
       "modal--scrolled-down": this.scrolledDown,
       "modal--hide-secondary-content-borders": this.hideSecondaryContentBorders,
-      "modal--remove-secondary-content-padding":
-        this.removeSecondaryContentPadding,
     });
 
     return (
@@ -328,6 +341,27 @@ export class SwirlModal {
                 style={{
                   maxWidth: this.secondaryContentMaxWidth,
                   flex: this.secondaryContentFlex,
+                  padding: Boolean(this.secondaryContentPadding)
+                    ? `var(--s-space-${this.secondaryContentPadding})`
+                    : undefined,
+                  paddingBlockEnd: Boolean(this.secondaryContentPaddingBlockEnd)
+                    ? `var(--s-space-${this.secondaryContentPaddingBlockEnd})`
+                    : undefined,
+                  paddingBlockStart: Boolean(
+                    this.secondaryContentPaddingBlockStart
+                  )
+                    ? `var(--s-space-${this.secondaryContentPaddingBlockStart})`
+                    : undefined,
+                  paddingInlineEnd: Boolean(
+                    this.secondaryContentPaddingInlineEnd
+                  )
+                    ? `var(--s-space-${this.secondaryContentPaddingInlineEnd})`
+                    : undefined,
+                  paddingInlineStart: Boolean(
+                    this.secondaryContentPaddingInlineStart
+                  )
+                    ? `var(--s-space-${this.secondaryContentPaddingInlineStart})`
+                    : undefined,
                 }}
               >
                 <slot name="secondary-content"></slot>

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
@@ -43,6 +43,13 @@ export class SwirlModal {
   @Prop() primaryActionLabel?: string;
   @Prop() secondaryActionLabel?: string;
   @Prop() variant?: SwirlModalVariant = "default";
+  @Prop() hideSecondaryContent?: boolean;
+  @Prop() primaryContentMaxWidth?: string;
+  @Prop() secondaryContentMaxWidth?: string;
+  @Prop() primaryContentFlex?: string;
+  @Prop() secondaryContentFlex?: string;
+  @Prop() hideSecondaryContentBorders?: boolean;
+  @Prop() removeSecondaryContentPadding?: boolean;
 
   @Event() modalClose: EventEmitter<void>;
   @Event() modalOpen: EventEmitter<void>;
@@ -235,12 +242,16 @@ export class SwirlModal {
       "modal--has-custom-footer": this.hasCustomFooter,
       "modal--has-custom-header": this.hasCustomHeader,
       "modal--has-header-tools": this.hasHeaderTools,
-      "modal--has-secondary-content": this.hasSecondaryContent,
+      "modal--has-secondary-content":
+        this.hasSecondaryContent && !this.hideSecondaryContent,
       "modal--hide-label": this.hideLabel,
       "modal--padded": this.padded,
       "modal--scrollable": this.scrollable,
       "modal--scrolled": this.scrolled,
       "modal--scrolled-down": this.scrolledDown,
+      "modal--hide-secondary-content-borders": this.hideSecondaryContentBorders,
+      "modal--remove-secondary-content-padding":
+        this.removeSecondaryContentPadding,
     });
 
     return (
@@ -294,7 +305,13 @@ export class SwirlModal {
               </header>
             )}
             <div class="modal__content-container">
-              <div class="modal__primary-content">
+              <div
+                class="modal__primary-content"
+                style={{
+                  maxWidth: this.primaryContentMaxWidth,
+                  flex: this.primaryContentFlex,
+                }}
+              >
                 <div class="modal__header-tools">
                   <slot name="header-tools"></slot>
                 </div>
@@ -306,7 +323,13 @@ export class SwirlModal {
                   <slot></slot>
                 </div>
               </div>
-              <div class="modal__secondary-content">
+              <div
+                class="modal__secondary-content"
+                style={{
+                  maxWidth: this.secondaryContentMaxWidth,
+                  flex: this.secondaryContentFlex,
+                }}
+              >
                 <slot name="secondary-content"></slot>
               </div>
             </div>

--- a/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.css
+++ b/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.css
@@ -10,4 +10,5 @@
   padding: var(--s-space-4);
   background-color: var(--s-surface-default);
   border-radius: var(--s-border-radius-base);
+  box-shadow: var(--s-shadow-level-1);
 }

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -14031,6 +14031,14 @@
           "description": ""
         },
         {
+          "name": "hide-secondary-content",
+          "description": ""
+        },
+        {
+          "name": "hide-secondary-content-borders",
+          "description": ""
+        },
+        {
           "name": "label",
           "description": ""
         },
@@ -14051,7 +14059,27 @@
           "description": ""
         },
         {
+          "name": "primary-content-flex",
+          "description": ""
+        },
+        {
+          "name": "primary-content-max-width",
+          "description": ""
+        },
+        {
+          "name": "remove-secondary-content-padding",
+          "description": ""
+        },
+        {
           "name": "secondary-action-label",
+          "description": ""
+        },
+        {
+          "name": "secondary-content-flex",
+          "description": ""
+        },
+        {
+          "name": "secondary-content-max-width",
           "description": ""
         },
         {

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -14067,10 +14067,6 @@
           "description": ""
         },
         {
-          "name": "remove-secondary-content-padding",
-          "description": ""
-        },
-        {
           "name": "secondary-action-label",
           "description": ""
         },
@@ -14081,6 +14077,171 @@
         {
           "name": "secondary-content-max-width",
           "description": ""
+        },
+        {
+          "name": "secondary-content-padding",
+          "description": "",
+          "values": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "12"
+            },
+            {
+              "name": "16"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "20"
+            },
+            {
+              "name": "24"
+            },
+            {
+              "name": "32"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "8"
+            }
+          ]
+        },
+        {
+          "name": "secondary-content-padding-block-end",
+          "description": "",
+          "values": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "12"
+            },
+            {
+              "name": "16"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "20"
+            },
+            {
+              "name": "24"
+            },
+            {
+              "name": "32"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "8"
+            }
+          ]
+        },
+        {
+          "name": "secondary-content-padding-block-start",
+          "description": "",
+          "values": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "12"
+            },
+            {
+              "name": "16"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "20"
+            },
+            {
+              "name": "24"
+            },
+            {
+              "name": "32"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "8"
+            }
+          ]
+        },
+        {
+          "name": "secondary-content-padding-inline-end",
+          "description": "",
+          "values": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "12"
+            },
+            {
+              "name": "16"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "20"
+            },
+            {
+              "name": "24"
+            },
+            {
+              "name": "32"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "8"
+            }
+          ]
+        },
+        {
+          "name": "secondary-content-padding-inline-start",
+          "description": "",
+          "values": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "12"
+            },
+            {
+              "name": "16"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "20"
+            },
+            {
+              "name": "24"
+            },
+            {
+              "name": "32"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "8"
+            }
+          ]
         },
         {
           "name": "variant",


### PR DESCRIPTION
The `post-preview` requires specific styles for the secondary content configuration. Added the option to specify the widths and flex properties of both the primary and secondary content, along with removing some paddings/borders.

Fixed the issue that the `swirl-image-grid` had, as it would not remove overlays (the +2 blurred text) as items were dynamically added/removed.

Added a box shadow to `the swirl-toggle-group`