### PR TITLE
Additional `swirl-modal` options & `aria-label` in `swirl-switch`

### DIFF
--- a/.changeset/twelve-lobsters-happen.md
+++ b/.changeset/twelve-lobsters-happen.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Add option to modify minHeight and contentGap of swirl-modal, add option to add
+an aria-label to swirl-switch

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -1598,6 +1598,7 @@ export namespace Components {
          */
         "close": (force?: boolean) => Promise<void>;
         "closeButtonLabel"?: string;
+        "contentGap"?: string;
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
@@ -1606,6 +1607,7 @@ export namespace Components {
         "label": string;
         "maxHeight"?: string;
         "maxWidth"?: string;
+        "minHeight"?: string;
         /**
           * Open the modal.
          */
@@ -1912,6 +1914,7 @@ export namespace Components {
         "inputName": string;
         "label"?: string;
         "labelPosition"?: SwirlSwitchLabelPosition;
+        "swirlAriaLabel"?: string;
         /**
           * Toggle the switch state programmatically.
          */
@@ -7072,6 +7075,7 @@ declare namespace LocalJSX {
     interface SwirlModal {
         "closable"?: boolean;
         "closeButtonLabel"?: string;
+        "contentGap"?: string;
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
@@ -7080,6 +7084,7 @@ declare namespace LocalJSX {
         "label": string;
         "maxHeight"?: string;
         "maxWidth"?: string;
+        "minHeight"?: string;
         "onModalClose"?: (event: SwirlModalCustomEvent<void>) => void;
         "onModalOpen"?: (event: SwirlModalCustomEvent<void>) => void;
         "onPrimaryAction"?: (event: SwirlModalCustomEvent<MouseEvent>) => void;
@@ -7393,6 +7398,7 @@ declare namespace LocalJSX {
         "label"?: string;
         "labelPosition"?: SwirlSwitchLabelPosition;
         "onValueChange"?: (event: SwirlSwitchCustomEvent<boolean>) => void;
+        "swirlAriaLabel"?: string;
         "value"?: string;
     }
     interface SwirlSymbol {

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -40,7 +40,7 @@ import { SwirlInlineStatusIntent, SwirlInlineStatusSize } from "./components/swi
 import { SwirlLinkColor, SwirlLinkTarget } from "./components/swirl-link/swirl-link";
 import { SwirlMenuVariant } from "./components/swirl-menu/swirl-menu";
 import { SwirlActionListItemIntent as SwirlActionListItemIntent1 } from "./components/swirl-action-list-item/swirl-action-list-item";
-import { SwirlModalPadding, SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
+import { SwirlModalSpacing, SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
 import { SwirlOptionListItemContext, SwirlOptionListItemRole } from "./components/swirl-option-list-item/swirl-option-list-item";
 import { SwirlPaginationVariant } from "./components/swirl-pagination/swirl-pagination";
 import { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover";
@@ -107,7 +107,7 @@ export { SwirlInlineStatusIntent, SwirlInlineStatusSize } from "./components/swi
 export { SwirlLinkColor, SwirlLinkTarget } from "./components/swirl-link/swirl-link";
 export { SwirlMenuVariant } from "./components/swirl-menu/swirl-menu";
 export { SwirlActionListItemIntent as SwirlActionListItemIntent1 } from "./components/swirl-action-list-item/swirl-action-list-item";
-export { SwirlModalPadding, SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
+export { SwirlModalSpacing, SwirlModalVariant } from "./components/swirl-modal/swirl-modal";
 export { SwirlOptionListItemContext, SwirlOptionListItemRole } from "./components/swirl-option-list-item/swirl-option-list-item";
 export { SwirlPaginationVariant } from "./components/swirl-pagination/swirl-pagination";
 export { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover";
@@ -1598,7 +1598,7 @@ export namespace Components {
          */
         "close": (force?: boolean) => Promise<void>;
         "closeButtonLabel"?: string;
-        "contentGap"?: string;
+        "contentGap"?: SwirlModalSpacing;
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
@@ -1619,11 +1619,11 @@ export namespace Components {
         "secondaryActionLabel"?: string;
         "secondaryContentFlex"?: string;
         "secondaryContentMaxWidth"?: string;
-        "secondaryContentPadding"?: SwirlModalPadding;
-        "secondaryContentPaddingBlockEnd"?: SwirlModalPadding;
-        "secondaryContentPaddingBlockStart"?: SwirlModalPadding;
-        "secondaryContentPaddingInlineEnd"?: SwirlModalPadding;
-        "secondaryContentPaddingInlineStart"?: SwirlModalPadding;
+        "secondaryContentPadding"?: SwirlModalSpacing;
+        "secondaryContentPaddingBlockEnd"?: SwirlModalSpacing;
+        "secondaryContentPaddingBlockStart"?: SwirlModalSpacing;
+        "secondaryContentPaddingInlineEnd"?: SwirlModalSpacing;
+        "secondaryContentPaddingInlineStart"?: SwirlModalSpacing;
         "variant"?: SwirlModalVariant;
     }
     interface SwirlOptionList {
@@ -7075,7 +7075,7 @@ declare namespace LocalJSX {
     interface SwirlModal {
         "closable"?: boolean;
         "closeButtonLabel"?: string;
-        "contentGap"?: string;
+        "contentGap"?: SwirlModalSpacing;
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
@@ -7097,11 +7097,11 @@ declare namespace LocalJSX {
         "secondaryActionLabel"?: string;
         "secondaryContentFlex"?: string;
         "secondaryContentMaxWidth"?: string;
-        "secondaryContentPadding"?: SwirlModalPadding;
-        "secondaryContentPaddingBlockEnd"?: SwirlModalPadding;
-        "secondaryContentPaddingBlockStart"?: SwirlModalPadding;
-        "secondaryContentPaddingInlineEnd"?: SwirlModalPadding;
-        "secondaryContentPaddingInlineStart"?: SwirlModalPadding;
+        "secondaryContentPadding"?: SwirlModalSpacing;
+        "secondaryContentPaddingBlockEnd"?: SwirlModalSpacing;
+        "secondaryContentPaddingBlockStart"?: SwirlModalSpacing;
+        "secondaryContentPaddingInlineEnd"?: SwirlModalSpacing;
+        "secondaryContentPaddingInlineStart"?: SwirlModalSpacing;
         "variant"?: SwirlModalVariant;
     }
     interface SwirlOptionList {

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
@@ -49,11 +49,13 @@ export class SwirlModal {
   @Prop() hideLabel?: boolean;
   @Prop() label!: string;
   @Prop() maxHeight?: string;
+  @Prop() minHeight?: string;
   @Prop() maxWidth?: string;
   @Prop() padded?: boolean = true;
   @Prop() primaryActionLabel?: string;
   @Prop() secondaryActionLabel?: string;
   @Prop() variant?: SwirlModalVariant = "default";
+  @Prop() contentGap?: string;
   @Prop() hideSecondaryContent?: boolean;
   @Prop() primaryContentMaxWidth?: string;
   @Prop() secondaryContentMaxWidth?: string;
@@ -284,6 +286,7 @@ export class SwirlModal {
             style={{
               "--swirl-modal-max-height": this.maxHeight,
               "--swirl-modal-height": this.height,
+              minHeight: this.minHeight,
               maxWidth: this.maxWidth,
             }}
           >
@@ -317,7 +320,10 @@ export class SwirlModal {
                 </div>
               </header>
             )}
-            <div class="modal__content-container">
+            <div
+              class="modal__content-container"
+              style={{ gap: this.contentGap }}
+            >
               <div
                 class="modal__primary-content"
                 style={{

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
@@ -16,7 +16,7 @@ import * as focusTrap from "focus-trap";
 
 export type SwirlModalVariant = "default" | "drawer";
 
-export type SwirlModalPadding =
+export type SwirlModalSpacing =
   | "0"
   | "2"
   | "4"
@@ -55,18 +55,18 @@ export class SwirlModal {
   @Prop() primaryActionLabel?: string;
   @Prop() secondaryActionLabel?: string;
   @Prop() variant?: SwirlModalVariant = "default";
-  @Prop() contentGap?: string;
+  @Prop() contentGap?: SwirlModalSpacing;
   @Prop() hideSecondaryContent?: boolean;
   @Prop() primaryContentMaxWidth?: string;
   @Prop() secondaryContentMaxWidth?: string;
   @Prop() primaryContentFlex?: string;
   @Prop() secondaryContentFlex?: string;
   @Prop() hideSecondaryContentBorders?: boolean;
-  @Prop() secondaryContentPadding?: SwirlModalPadding;
-  @Prop() secondaryContentPaddingBlockEnd?: SwirlModalPadding;
-  @Prop() secondaryContentPaddingBlockStart?: SwirlModalPadding;
-  @Prop() secondaryContentPaddingInlineEnd?: SwirlModalPadding;
-  @Prop() secondaryContentPaddingInlineStart?: SwirlModalPadding;
+  @Prop() secondaryContentPadding?: SwirlModalSpacing;
+  @Prop() secondaryContentPaddingBlockEnd?: SwirlModalSpacing;
+  @Prop() secondaryContentPaddingBlockStart?: SwirlModalSpacing;
+  @Prop() secondaryContentPaddingInlineEnd?: SwirlModalSpacing;
+  @Prop() secondaryContentPaddingInlineStart?: SwirlModalSpacing;
 
   @Event() modalClose: EventEmitter<void>;
   @Event() modalOpen: EventEmitter<void>;
@@ -322,7 +322,11 @@ export class SwirlModal {
             )}
             <div
               class="modal__content-container"
-              style={{ gap: this.contentGap }}
+              style={{
+                gap: this.contentGap
+                  ? `var(--s-space-${this.contentGap})`
+                  : undefined,
+              }}
             >
               <div
                 class="modal__primary-content"

--- a/packages/swirl-components/src/components/swirl-switch/swirl-switch.tsx
+++ b/packages/swirl-components/src/components/swirl-switch/swirl-switch.tsx
@@ -35,6 +35,7 @@ export class SwirlSwitch {
   @Prop() label?: string;
   @Prop() labelPosition?: SwirlSwitchLabelPosition = "end";
   @Prop() value?: string;
+  @Prop() swirlAriaLabel?: string;
 
   @StencilEvent() valueChange: EventEmitter<boolean>;
 
@@ -76,6 +77,11 @@ export class SwirlSwitch {
             <swirl-visually-hidden>
               <input
                 aria-checked={ariaCheckedLabel}
+                aria-label={
+                  !this.hideLabel && this.swirlAriaLabel
+                    ? this.swirlAriaLabel
+                    : undefined
+                }
                 checked={on}
                 class="switch__input"
                 disabled={this.disabled}
@@ -93,8 +99,10 @@ export class SwirlSwitch {
           {this.label && !this.hideLabel && (
             <span class="switch__label">{this.label}</span>
           )}
-          {this.label && this.hideLabel && (
-            <swirl-visually-hidden>{this.label}</swirl-visually-hidden>
+          {this.hideLabel && (
+            <swirl-visually-hidden>
+              {this.swirlAriaLabel || this.label}
+            </swirl-visually-hidden>
           )}
         </label>
       </Host>

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -14019,6 +14019,10 @@
           "description": ""
         },
         {
+          "name": "content-gap",
+          "description": ""
+        },
+        {
           "name": "height",
           "description": ""
         },
@@ -14048,6 +14052,10 @@
         },
         {
           "name": "max-width",
+          "description": ""
+        },
+        {
+          "name": "min-height",
           "description": ""
         },
         {
@@ -15668,6 +15676,10 @@
               "name": "start"
             }
           ]
+        },
+        {
+          "name": "swirl-aria-label",
+          "description": ""
         },
         {
           "name": "value",

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -14020,7 +14020,36 @@
         },
         {
           "name": "content-gap",
-          "description": ""
+          "description": "",
+          "values": [
+            {
+              "name": "0"
+            },
+            {
+              "name": "12"
+            },
+            {
+              "name": "16"
+            },
+            {
+              "name": "2"
+            },
+            {
+              "name": "20"
+            },
+            {
+              "name": "24"
+            },
+            {
+              "name": "32"
+            },
+            {
+              "name": "4"
+            },
+            {
+              "name": "8"
+            }
+          ]
         },
         {
           "name": "height",

--- a/packages/swirl-tokens/dart/lib/styles.dark.dart
+++ b/packages/swirl-tokens/dart/lib/styles.dark.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Wed, 20 Nov 2024 10:52:12 GMT
+// Generated on Tue, 26 Nov 2024 10:28:32 GMT
 
 
 

--- a/packages/swirl-tokens/dart/lib/styles.dark.dart
+++ b/packages/swirl-tokens/dart/lib/styles.dark.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Tue, 26 Nov 2024 10:28:32 GMT
+// Generated on Tue, 26 Nov 2024 13:02:06 GMT
 
 
 

--- a/packages/swirl-tokens/dart/lib/styles.light.dart
+++ b/packages/swirl-tokens/dart/lib/styles.light.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Wed, 20 Nov 2024 10:52:12 GMT
+// Generated on Tue, 26 Nov 2024 10:28:32 GMT
 
 
 

--- a/packages/swirl-tokens/dart/lib/styles.light.dart
+++ b/packages/swirl-tokens/dart/lib/styles.light.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Tue, 26 Nov 2024 10:28:32 GMT
+// Generated on Tue, 26 Nov 2024 13:02:06 GMT
 
 
 


### PR DESCRIPTION
Added the option to modify the `min-height` and the `gap` of modal content containers.
Added the option to define the `aria-label` for `swirl-switch`.
