### PR TITLE
Allow to change the initial mobile view of swirl-app-layout

### DIFF
--- a/.changeset/fluffy-donuts-switch.md
+++ b/.changeset/fluffy-donuts-switch.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Add "initial-mobile-view" prop to swirl-app-layout

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -226,6 +226,7 @@ export namespace Components {
           * Hide the sidebar
          */
         "hideSidebar": () => Promise<void>;
+        "initialMobileView"?: SwirlAppLayoutMobileView;
         "navigationBackButtonLabel"?: string;
         "navigationExpansionStateStorageKey"?: string;
         "navigationLabel"?: string;
@@ -5875,6 +5876,7 @@ declare namespace LocalJSX {
         "ctaLabel"?: string;
         "hasNavigation"?: boolean;
         "hideAppBar"?: boolean;
+        "initialMobileView"?: SwirlAppLayoutMobileView;
         "navigationBackButtonLabel"?: string;
         "navigationExpansionStateStorageKey"?: string;
         "navigationLabel"?: string;

--- a/packages/swirl-components/src/components/swirl-app-layout/swirl-app-layout.tsx
+++ b/packages/swirl-components/src/components/swirl-app-layout/swirl-app-layout.tsx
@@ -60,6 +60,7 @@ export class SwirlAppLayout {
   @Prop() ctaLabel?: string;
   @Prop({ mutable: true }) hasNavigation: boolean;
   @Prop() hideAppBar?: boolean;
+  @Prop() initialMobileView?: SwirlAppLayoutMobileView;
   @Prop() navigationBackButtonLabel?: string = "Go back";
   @Prop() navigationExpansionStateStorageKey?: string =
     SWIRL_APP_LAYOUT_NAV_EXPANSION_STATE_STORAGE_KEY;
@@ -114,6 +115,10 @@ export class SwirlAppLayout {
   private transitionTimeout: NodeJS.Timeout;
 
   componentWillLoad() {
+    if (this.initialMobileView) {
+      this.mobileView = this.initialMobileView;
+    }
+
     this.mutationObserver = new MutationObserver(() => {
       this.updateCustomAppBarBackButtonStatus();
       this.updateNavigationStatus();

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -296,6 +296,21 @@
           "description": ""
         },
         {
+          "name": "initial-mobile-view",
+          "description": "",
+          "values": [
+            {
+              "name": "body"
+            },
+            {
+              "name": "navigation"
+            },
+            {
+              "name": "sidebar"
+            }
+          ]
+        },
+        {
           "name": "navigation-back-button-label",
           "description": ""
         },


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-677/flip-web-disable-mobile-sliding-transitions-for-pages-inside-flutter)
- [Storybook](https://icy-water-049ec4003-892.westeurope.3.azurestaticapps.net/?path=/docs/components-swirlapplayout--docs)
