### PR TITLE
ENG-511 Image intersection issues

### DIFF
--- a/.changeset/poor-spies-fetch.md
+++ b/.changeset/poor-spies-fetch.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Intersecting image-grid-item images only load if they're visible in the final
+state

--- a/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
+++ b/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
@@ -11,6 +11,7 @@ import {
   Watch,
 } from "@stencil/core";
 import classnames from "classnames";
+import { debounce } from "../../utils";
 
 export type SwirlImageGridItemLoading =
   | "lazy"
@@ -102,19 +103,19 @@ export class SwirlImageGridItem {
       return;
     }
 
-    this.intersectionObserver = new IntersectionObserver(
-      this.onVisibilityChange.bind(this),
-      {
-        threshold: 0,
-      }
-    );
+    this.intersectionObserver = new IntersectionObserver((entries) => {
+      this.handleIntersectionEntries(entries);
+    });
 
     this.intersectionObserver.observe(this.el);
   }
 
-  private onVisibilityChange(entries: IntersectionObserverEntry[]) {
-    this.inViewport = entries.some((entry) => entry.isIntersecting);
-  }
+  private handleIntersectionEntries = debounce(
+    (entries: IntersectionObserverEntry[]) => {
+      this.inViewport = entries[entries.length - 1].isIntersecting;
+    },
+    250
+  );
 
   private onLoad = () => {
     this.error = false;

--- a/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
+++ b/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
@@ -113,7 +113,7 @@ export class SwirlImageGridItem {
   private handleIntersectionEntries = debounce(
     (entries: IntersectionObserverEntry[]) => {
       const sorted = [...entries].sort((a, b) => a.time - b.time);
-      this.inViewport = sorted[sorted.length - 1].isIntersecting;
+      this.inViewport = sorted.at(-1).isIntersecting;
     },
     250
   );

--- a/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
+++ b/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
@@ -112,7 +112,8 @@ export class SwirlImageGridItem {
 
   private handleIntersectionEntries = debounce(
     (entries: IntersectionObserverEntry[]) => {
-      this.inViewport = entries[entries.length - 1].isIntersecting;
+      const sorted = [...entries].sort((a, b) => a.time - b.time);
+      this.inViewport = sorted[sorted.length - 1].isIntersecting;
     },
     250
   );


### PR DESCRIPTION
## Summary
- [Ticket](https://linear.app/flip/issue/ENG-511/check-intersecting-loading-swirl-image-grid-inside-chat)

This solution is based on two ideas:

1. As clients (Angular in our case) render the DOM, these images might at some point be intersecting with the viewport, while it's not visible to the user. Instead of checking all of the intersection entries, we should only check the last one, as it's the "final" state that the user sees.
2. Sometimes browsers won't be able to bundle these intersection entries together, e.g. when you manually reload. This is why I also introduced a debounce so that we again only handle the last state.

Additionally sorted the entries as recommended by MDN