### PR TITLE
Determine first day of week for date picker via locale

### DIFF
--- a/.changeset/proud-socks-behave.md
+++ b/.changeset/proud-socks-behave.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Let swirl-date-picker determine the first day of the week via the locale

--- a/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.spec.tsx
@@ -13,7 +13,7 @@ describe("swirl-date-picker", () => {
     expect(page.root).toEqualHtml(`
       <swirl-date-picker range="true">
         <mock:shadow-root>
-          <wc-datepicker elementclassname="date-picker" firstdayofweek="0" locale="en-US" range=""></wc-datepicker>
+          <wc-datepicker elementclassname="date-picker" firstdayofweek="7" locale="en-US" range=""></wc-datepicker>
         </mock:shadow-root>
       </swirl-date-picker>
     `);

--- a/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.tsx
+++ b/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.tsx
@@ -49,7 +49,7 @@ export class SwirlDatePicker {
       this.firstDayOfWeek =
         "getWeekInfo" in locale
           ? locale.getWeekInfo().firstDay
-          : locale.weekInfo?.firstDay;
+          : locale.weekInfo?.firstDay ?? 0;
     }
   }
 

--- a/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.tsx
+++ b/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.tsx
@@ -9,9 +9,20 @@ import {
 } from "@stencil/core";
 import { WcDatepickerCustomEvent } from "wc-datepicker/dist/types/components";
 import { WCDatepickerLabels } from "wc-datepicker/dist/types/components/wc-datepicker/wc-datepicker";
+import { getISODateString, removeTimezoneOffset } from "../../utils";
 
 import "wc-datepicker";
-import { getISODateString, removeTimezoneOffset } from "../../utils";
+
+interface WeekInfo {
+  firstDay: number;
+  weekendStart: number;
+  weekendEnd: number;
+}
+
+interface LocaleWithWeekInfo extends Intl.Locale {
+  getWeekInfo?(): WeekInfo;
+  weekInfo?: WeekInfo;
+}
 
 @Component({
   shadow: true,
@@ -22,7 +33,7 @@ export class SwirlDatePicker {
   @Element() el: HTMLElement;
 
   @Prop() disableDate?: (date: Date) => boolean = () => false;
-  @Prop() firstDayOfWeek?: number = 0;
+  @Prop({ mutable: true }) firstDayOfWeek?: number = 0;
   @Prop() labels?: WCDatepickerLabels;
   @Prop() locale?: string = "en-US";
   @Prop() range?: boolean;
@@ -30,6 +41,17 @@ export class SwirlDatePicker {
   @Prop({ mutable: true }) value?: Date | Date[];
 
   @Event({ bubbles: false }) valueChange: EventEmitter<Date | Date[]>;
+
+  componentWillLoad() {
+    if (!this.firstDayOfWeek) {
+      const locale = new Intl.Locale(this.locale) as LocaleWithWeekInfo;
+
+      this.firstDayOfWeek =
+        "getWeekInfo" in locale
+          ? locale.getWeekInfo().firstDay
+          : locale.weekInfo?.firstDay;
+    }
+  }
 
   private onClick = (event: MouseEvent) => {
     event.stopPropagation();

--- a/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.tsx
+++ b/packages/swirl-components/src/components/swirl-date-picker/swirl-date-picker.tsx
@@ -13,10 +13,10 @@ import { getISODateString, removeTimezoneOffset } from "../../utils";
 
 import "wc-datepicker";
 
+// Extend Locale interface with getWeekInfo data
+// (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo)
 interface WeekInfo {
   firstDay: number;
-  weekendStart: number;
-  weekendEnd: number;
 }
 
 interface LocaleWithWeekInfo extends Intl.Locale {


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-659/scheduling-posts-starts-on-a-monday)
- [Storybook](https://icy-water-049ec4003-896.westeurope.3.azurestaticapps.net/?path=/docs/components-swirldatepicker--docs)
