### PR TITLE
Fix swirl-button colors for plain/primary variant

### DIFF
--- a/.changeset/cold-dancers-wonder.md
+++ b/.changeset/cold-dancers-wonder.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix hover and active state swirl-button colors for plain/primary variant.

--- a/packages/swirl-components/src/components/swirl-button/swirl-button.css
+++ b/packages/swirl-components/src/components/swirl-button/swirl-button.css
@@ -281,19 +281,19 @@
   &.button--intent-primary {
     color: var(--s-interactive-primary-default);
 
-    &:hover {
-      color: var(--s-interactive-primary-default);
-
-      & .button__icon {
-        color: var(--s-interactive-primary-default);
-      }
-    }
-
-    &:active {
+    &:hover:not(:disabled):not(.button--disabled) {
       color: var(--s-interactive-primary-hovered);
 
       & .button__icon {
         color: var(--s-interactive-primary-hovered);
+      }
+    }
+
+    &:active:not(:disabled):not(.button--disabled) {
+      color: var(--s-interactive-primary-pressed);
+
+      & .button__icon {
+        color: var(--s-interactive-primary-pressed);
       }
     }
 


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-723/swirl-web-primary-plain-button-hoverstate-turns-grey)
- [Storybook](#)
