### PR TITLE
ENG-877 Display modal custom header divider when scrolled

### DIFF
--- a/.changeset/hip-sheep-fetch.md
+++ b/.changeset/hip-sheep-fetch.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Display a modal custom header border only if it's scrolled

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
@@ -264,6 +264,10 @@
     &.modal--has-header-tools .modal__header-tools {
       border-bottom-color: var(--s-border-default);
     }
+
+    .modal__custom-header {
+      border-bottom-color: var(--s-border-default);
+    }
   }
 }
 
@@ -351,6 +355,10 @@
   display: none;
   flex-shrink: 0;
   border-bottom: var(--s-border-width-default) solid var(--s-border-default);
+
+  @media (--from-tablet) {
+    border-bottom-color: transparent;
+  }
 }
 
 .modal__heading {


### PR DESCRIPTION
## Summary

Custom headers in the modal will only display a divider if the screen is < tablet or if the content is scrolled.
