### PR TITLE
ENG-1002 Fix `swirl-avatar` intersection observer

### DIFF
--- a/.changeset/small-monkeys-raise.md
+++ b/.changeset/small-monkeys-raise.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Fix swirl-avatar intersection observer

--- a/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
@@ -78,6 +78,7 @@ export class SwirlAvatar {
   @State() loaded = false;
   @State() imageAvailable: boolean | undefined;
   @State() inViewport = false;
+  @State() componentLoaded = false;
 
   @Event() imageError: EventEmitter<void>;
   @Event() imageLoad: EventEmitter<void>;
@@ -86,6 +87,13 @@ export class SwirlAvatar {
 
   componentDidLoad() {
     this.setupIntersectionObserver();
+    this.componentLoaded = true;
+  }
+
+  connectedCallback() {
+    if (this.componentLoaded) {
+      this.setupIntersectionObserver();
+    }
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-1002/something-broken-with-the-pin-comment-behavior)

Component can get re-attached, in that case disconnectedCallback() is called and the intersection observer is canceled. Now we also track again on connectedCallback().