### PR TITLE
Fix media query listeners

### DIFF
--- a/.changeset/sour-oranges-hide.md
+++ b/.changeset/sour-oranges-hide.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Fix media query listeners

--- a/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.tsx
@@ -38,7 +38,10 @@ export class SwirlActionListItem {
   componentDidLoad() {
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   componentDidRender() {

--- a/packages/swirl-components/src/components/swirl-app-layout/swirl-app-layout.tsx
+++ b/packages/swirl-components/src/components/swirl-app-layout/swirl-app-layout.tsx
@@ -136,7 +136,10 @@ export class SwirlAppLayout {
   }
 
   componentDidLoad() {
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
 
     queueMicrotask(() => {
       this.isDesktop = this.desktopMediaQuery.matches;

--- a/packages/swirl-components/src/components/swirl-banner/swirl-banner.tsx
+++ b/packages/swirl-components/src/components/swirl-banner/swirl-banner.tsx
@@ -57,7 +57,10 @@ export class SwirlBanner {
   componentDidLoad() {
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   disconnectedCallback() {

--- a/packages/swirl-components/src/components/swirl-button/swirl-button.tsx
+++ b/packages/swirl-components/src/components/swirl-button/swirl-button.tsx
@@ -73,7 +73,10 @@ export class SwirlButton {
     this.forceIconProps(this.desktopMediaQuery.matches);
     this.updateFormAttribute();
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   componentDidRender() {

--- a/packages/swirl-components/src/components/swirl-chip/swirl-chip.tsx
+++ b/packages/swirl-components/src/components/swirl-chip/swirl-chip.tsx
@@ -55,7 +55,10 @@ export class SwirlChip {
   componentDidLoad() {
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   disconnectedCallback() {

--- a/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
+++ b/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
@@ -77,7 +77,10 @@ export class SwirlDateInput {
 
     this.updateIconSize(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
 
     // see https://stackoverflow.com/a/27314017
     if (this.autoFocus) {

--- a/packages/swirl-components/src/components/swirl-inline-error/swirl-inline-error.tsx
+++ b/packages/swirl-components/src/components/swirl-inline-error/swirl-inline-error.tsx
@@ -19,7 +19,10 @@ export class SwirlInlineError {
   componentDidLoad() {
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   disconnectedCallback() {

--- a/packages/swirl-components/src/components/swirl-inline-status/swirl-inline-status.tsx
+++ b/packages/swirl-components/src/components/swirl-inline-status/swirl-inline-status.tsx
@@ -31,7 +31,10 @@ export class SwirlInlineStatus {
   componentDidLoad() {
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   disconnectedCallback() {

--- a/packages/swirl-components/src/components/swirl-menu/swirl-menu.tsx
+++ b/packages/swirl-components/src/components/swirl-menu/swirl-menu.tsx
@@ -69,7 +69,7 @@ export class SwirlMenu {
   }
 
   componentDidLoad() {
-    this.mobileMediaQuery.onchange = this.mediaQueryHandler;
+    this.mobileMediaQuery.addEventListener("change", this.mediaQueryHandler);
     this.parentMenu = closestPassShadow(
       this.el.parentElement,
       "swirl-menu"

--- a/packages/swirl-components/src/components/swirl-option-list-item/swirl-option-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-option-list-item/swirl-option-list-item.tsx
@@ -56,7 +56,10 @@ export class SwirlOptionListItem {
     this.forceIconProps(this.desktopMediaQuery.matches);
     this.updateIconSize(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   disconnectedCallback() {

--- a/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.tsx
@@ -25,7 +25,10 @@ export class SwirlResourceListFileItem {
   componentDidLoad() {
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   disconnectedCallback() {

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
@@ -77,7 +77,10 @@ export class SwirlResourceListItem {
     this.forceIconProps(this.desktopMediaQuery.matches);
     this.updateIconSize(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
     this.makeControlUnfocusable();
 
     if (Boolean(this.menuTriggerId)) {

--- a/packages/swirl-components/src/components/swirl-search/swirl-search.tsx
+++ b/packages/swirl-components/src/components/swirl-search/swirl-search.tsx
@@ -47,7 +47,10 @@ export class SwirlSearch {
   componentDidLoad() {
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
 
     // see https://stackoverflow.com/a/27314017
     if (this.autoFocus) {

--- a/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.tsx
+++ b/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.tsx
@@ -92,7 +92,10 @@ export class SwirlTextInput implements SwirlFormInput {
   componentDidLoad() {
     this.updateIconSize(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
 
     // see https://stackoverflow.com/a/27314017
     if (this.autoFocus) {

--- a/packages/swirl-components/src/components/swirl-time-input/swirl-time-input.tsx
+++ b/packages/swirl-components/src/components/swirl-time-input/swirl-time-input.tsx
@@ -67,7 +67,10 @@ export class SwirlTimeInput {
 
     this.updateIconSize(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
 
     // see https://stackoverflow.com/a/27314017
     if (this.autoFocus) {

--- a/packages/swirl-components/src/components/swirl-toast/swirl-toast.tsx
+++ b/packages/swirl-components/src/components/swirl-toast/swirl-toast.tsx
@@ -43,7 +43,10 @@ export class SwirlToast {
 
     this.forceIconProps(this.desktopMediaQuery.matches);
 
-    this.desktopMediaQuery.onchange = this.desktopMediaQueryHandler;
+    this.desktopMediaQuery.addEventListener(
+      "change",
+      this.desktopMediaQueryHandler
+    );
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
The `onchange` callback would not be removed with `removeEventListener`. This change should now make sure the listeners are properly removed. 