### PR TITLE
Replace onLoad/onError img attributes with addEventListener subscriptions

### DIFF
--- a/.changeset/itchy-buttons-ring.md
+++ b/.changeset/itchy-buttons-ring.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Correctly unsubscribe from img onLoad and onError events when unmounted

--- a/packages/swirl-components/src/components/swirl-app-icon/swirl-app-icon.tsx
+++ b/packages/swirl-components/src/components/swirl-app-icon/swirl-app-icon.tsx
@@ -12,12 +12,31 @@ export class SwirlAppIcon {
 
   @State() imageAvailable: boolean | undefined;
 
+  private imgEl: HTMLImageElement | undefined;
+
+  disconnectedCallback() {
+    this.imgEl?.removeEventListener("load", this.setImageAvailable);
+    this.imgEl?.removeEventListener("error", this.setImageUnavailable);
+  }
+
   private setImageAvailable = () => {
     this.imageAvailable = true;
   };
 
   private setImageUnavailable = () => {
     this.imageAvailable = false;
+  };
+
+  private onImageElementUpdate = (el: HTMLImageElement) => {
+    this.imgEl?.removeEventListener("load", this.setImageAvailable);
+    this.imgEl?.removeEventListener("error", this.setImageUnavailable);
+
+    this.imgEl = el;
+
+    if (this.imgEl) {
+      this.imgEl.addEventListener("load", this.setImageAvailable);
+      this.imgEl.addEventListener("error", this.setImageUnavailable);
+    }
   };
 
   render() {
@@ -39,8 +58,7 @@ export class SwirlAppIcon {
             <img
               alt=""
               height="256"
-              onError={this.setImageUnavailable}
-              onLoad={this.setImageAvailable}
+              ref={this.onImageElementUpdate}
               src={this.src}
               width="256"
             />

--- a/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
@@ -83,6 +83,7 @@ export class SwirlAvatar {
   @Event() imageLoad: EventEmitter<void>;
 
   private componentLoaded = false;
+  private imgEl: HTMLImageElement | undefined;
   private intersectionObserver: IntersectionObserver;
 
   componentDidLoad() {
@@ -98,6 +99,8 @@ export class SwirlAvatar {
 
   disconnectedCallback() {
     this.intersectionObserver?.disconnect();
+    this.imgEl?.removeEventListener("load", this.setImageAvailable);
+    this.imgEl?.removeEventListener("error", this.setImageUnavailable);
   }
 
   @Watch("src")
@@ -123,6 +126,18 @@ export class SwirlAvatar {
   private onVisibilityChange(entries: IntersectionObserverEntry[]) {
     this.inViewport = entries.some((entry) => entry.isIntersecting);
   }
+
+  private onImageElementUpdate = (el: HTMLImageElement) => {
+    this.imgEl?.removeEventListener("load", this.setImageAvailable);
+    this.imgEl?.removeEventListener("error", this.setImageUnavailable);
+
+    this.imgEl = el;
+
+    if (this.imgEl) {
+      this.imgEl.addEventListener("load", this.setImageAvailable);
+      this.imgEl.addEventListener("error", this.setImageUnavailable);
+    }
+  };
 
   private setImageAvailable = () => {
     this.imageAvailable = true;
@@ -214,8 +229,7 @@ export class SwirlAvatar {
                 loading={
                   this.loading !== "intersecting" ? this.loading : undefined
                 }
-                onError={this.setImageUnavailable}
-                onLoad={this.setImageAvailable}
+                ref={this.onImageElementUpdate}
                 src={this.src}
                 width={swirlAvatarSizeMappings[this.size]}
               />

--- a/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-image/swirl-file-viewer-image.tsx
+++ b/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-image/swirl-file-viewer-image.tsx
@@ -29,7 +29,7 @@ export class SwirlFileViewerImage {
 
   @Event() activate: EventEmitter<HTMLElement>;
 
-  private imageEl: HTMLImageElement;
+  private imageEl: HTMLImageElement | undefined;
   private panning: boolean;
   private panX: number = 0;
   private panY: number = 0;
@@ -43,6 +43,11 @@ export class SwirlFileViewerImage {
 
   componentDidLoad() {
     this.activate.emit(this.el);
+  }
+
+  disconnectedCallback() {
+    this.imageEl?.removeEventListener("load", this.onLoad);
+    this.imageEl?.removeEventListener("error", this.onError);
   }
 
   @Watch("file")
@@ -281,6 +286,18 @@ export class SwirlFileViewerImage {
     this.panning = false;
   };
 
+  private onImageElementUpdate = (el: HTMLImageElement) => {
+    this.imageEl?.removeEventListener("load", this.onLoad);
+    this.imageEl?.removeEventListener("error", this.onError);
+
+    this.imageEl = el;
+
+    if (this.imageEl) {
+      this.imageEl.addEventListener("load", this.onLoad);
+      this.imageEl.addEventListener("error", this.onError);
+    }
+  };
+
   render() {
     return (
       <Host
@@ -303,9 +320,7 @@ export class SwirlFileViewerImage {
         <img
           alt={this.description}
           class="file-viewer-image__image"
-          onError={this.onError}
-          onLoad={this.onLoad}
-          ref={(el) => (this.imageEl = el)}
+          ref={this.onImageElementUpdate}
           src={this.file}
         />
         {this.loading && (

--- a/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
+++ b/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
@@ -49,7 +49,7 @@ export class SwirlImageGridItem {
   @Event() imageLoad: EventEmitter<void>;
 
   private intersectionObserver: IntersectionObserver;
-  private img?: HTMLImageElement;
+  private img: HTMLImageElement | undefined;
 
   /**
    * Start Gif playback.
@@ -96,6 +96,8 @@ export class SwirlImageGridItem {
   disconnectedCallback() {
     this.intersectionObserver?.disconnect();
     this.computedSrc = "";
+    this.img?.removeEventListener("load", this.onLoad);
+    this.img?.removeEventListener("error", this.onError);
   }
 
   private setupIntersectionObserver() {
@@ -167,6 +169,18 @@ export class SwirlImageGridItem {
     });
   }
 
+  private onImageElementUpdate = (el: HTMLImageElement) => {
+    this.img?.removeEventListener("load", this.onLoad);
+    this.img?.removeEventListener("error", this.onError);
+
+    this.img = el;
+
+    if (this.img) {
+      this.img.addEventListener("load", this.onLoad);
+      this.img.addEventListener("error", this.onError);
+    }
+  };
+
   render() {
     const Tag = this.interactive ? "button" : "div";
 
@@ -204,9 +218,7 @@ export class SwirlImageGridItem {
               loading={
                 this.loading !== "intersecting" ? this.loading : undefined
               }
-              onError={this.onError}
-              onLoad={this.onLoad}
-              ref={(el) => (this.img = el)}
+              ref={this.onImageElementUpdate}
               src={this.computedSrc}
             />
           ) : (


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-1151/fix-swirl-onloadonerror-listeners)
- [Storybook](#)
