### PR TITLE
ENG-788 Set resource-list-item label min-height

### DIFF
--- a/.changeset/nine-peaches-sneeze.md
+++ b/.changeset/nine-peaches-sneeze.md
@@ -4,4 +4,4 @@
 "@getflip/swirl-components-react": minor
 ---
 
-Add option to unset swirl-resource-list-item label min-height
+Add option to set swirl-resource-list-item label min-height

--- a/.changeset/nine-peaches-sneeze.md
+++ b/.changeset/nine-peaches-sneeze.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Add option to unset swirl-resource-list-item label min-height

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -1883,6 +1883,7 @@ export namespace Components {
         "href"?: string;
         "interactive"?: boolean;
         "label": string;
+        "labelMinHeight"?: string;
         "labelWeight"?: SwirlResourceListItemLabelWeight;
         "labelWrap"?: boolean;
         "menuTriggerId"?: string;
@@ -1890,7 +1891,6 @@ export namespace Components {
         "meta"?: string;
         "selectable"?: boolean;
         "swirlAriaLabel"?: string;
-        "unsetLabelMinHeight"?: boolean;
         "value"?: string;
     }
     interface SwirlResourceListSection {
@@ -7571,6 +7571,7 @@ declare namespace LocalJSX {
         "href"?: string;
         "interactive"?: boolean;
         "label": string;
+        "labelMinHeight"?: string;
         "labelWeight"?: SwirlResourceListItemLabelWeight;
         "labelWrap"?: boolean;
         "menuTriggerId"?: string;
@@ -7580,7 +7581,6 @@ declare namespace LocalJSX {
         "onValueChange"?: (event: SwirlResourceListItemCustomEvent<boolean>) => void;
         "selectable"?: boolean;
         "swirlAriaLabel"?: string;
-        "unsetLabelMinHeight"?: boolean;
         "value"?: string;
     }
     interface SwirlResourceListSection {

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -1890,6 +1890,7 @@ export namespace Components {
         "meta"?: string;
         "selectable"?: boolean;
         "swirlAriaLabel"?: string;
+        "unsetLabelMinHeight"?: boolean;
         "value"?: string;
     }
     interface SwirlResourceListSection {
@@ -7579,6 +7580,7 @@ declare namespace LocalJSX {
         "onValueChange"?: (event: SwirlResourceListItemCustomEvent<boolean>) => void;
         "selectable"?: boolean;
         "swirlAriaLabel"?: string;
+        "unsetLabelMinHeight"?: boolean;
         "value"?: string;
     }
     interface SwirlResourceListSection {

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
@@ -51,7 +51,7 @@ export class SwirlResourceListItem {
   @Prop() label!: string;
   @Prop() labelWeight?: SwirlResourceListItemLabelWeight = "medium";
   @Prop() labelWrap?: boolean;
-  @Prop() unsetLabelMinHeight?: boolean;
+  @Prop() labelMinHeight?: string;
   @Prop() menuTriggerId?: string;
   @Prop() menuTriggerLabel?: string = "Options";
   @Prop() meta?: string;
@@ -214,7 +214,7 @@ export class SwirlResourceListItem {
               this.controlContainer?.getBoundingClientRect().width
             }px + var(--s-space-16))`
           : undefined,
-      minHeight: this.unsetLabelMinHeight ? "unset" : undefined,
+      minHeight: this.labelMinHeight ?? undefined,
     };
 
     const className = classnames(

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
@@ -51,6 +51,7 @@ export class SwirlResourceListItem {
   @Prop() label!: string;
   @Prop() labelWeight?: SwirlResourceListItemLabelWeight = "medium";
   @Prop() labelWrap?: boolean;
+  @Prop() unsetLabelMinHeight?: boolean;
   @Prop() menuTriggerId?: string;
   @Prop() menuTriggerLabel?: string = "Options";
   @Prop() meta?: string;
@@ -206,14 +207,15 @@ export class SwirlResourceListItem {
     const ariaChecked = this.selectable ? String(this.checked) : undefined;
     const role = this.interactive && this.selectable ? "checkbox" : undefined;
 
-    const labelContainerStyles =
-      !showMeta && Boolean(this.controlContainer)
-        ? {
-            paddingRight: `calc(${
+    const labelContainerStyles = {
+      paddingRight:
+        !showMeta && Boolean(this.controlContainer)
+          ? `calc(${
               this.controlContainer?.getBoundingClientRect().width
-            }px + var(--s-space-16))`,
-          }
-        : undefined;
+            }px + var(--s-space-16))`
+          : undefined,
+      minHeight: this.unsetLabelMinHeight ? "unset" : undefined,
+    };
 
     const className = classnames(
       "resource-list-item",

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -16175,6 +16175,10 @@
           "description": ""
         },
         {
+          "name": "unset-label-min-height",
+          "description": ""
+        },
+        {
           "name": "value",
           "description": ""
         }

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -16133,6 +16133,10 @@
           "description": ""
         },
         {
+          "name": "label-min-height",
+          "description": ""
+        },
+        {
           "name": "label-weight",
           "description": "",
           "values": [
@@ -16172,10 +16176,6 @@
         },
         {
           "name": "swirl-aria-label",
-          "description": ""
-        },
-        {
-          "name": "unset-label-min-height",
           "description": ""
         },
         {


### PR DESCRIPTION
The label in `swirl-resource-list-item` has some `min-height` set. This gives us the option to unset it.