### PR TITLE
Use Stencil's experimental slot fixes

### DIFF
--- a/packages/swirl-components/stencil.config.ts
+++ b/packages/swirl-components/stencil.config.ts
@@ -111,6 +111,7 @@ export const config: Config = {
   ],
   extras: {
     enableImportInjection: true,
+    experimentalSlotFixes: true,
   },
   plugins: [
     postcss({


### PR DESCRIPTION
This should fix some issues we are having with our component slots when used in Angular or React apps. https://linear.app/flip/issue/ENG-1168/swirl-bug-org-chart-boldsubdued-swapping

- React issue: https://linear.app/flip/issue/ENG-1168/swirl-bug-org-chart-boldsubdued-swapping
- Dynamic slots issue in Angular: Some of you might have noticed that the Swirl components don't work when used with structural directives or @if i. Angular. This should also fix those issues.