### PR TITLE
Update the SwirlCarousel scroll position when resized

### DIFF
--- a/.changeset/twelve-ants-rush.md
+++ b/.changeset/twelve-ants-rush.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix carousel control visibility issue when browser is resized"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "swirl",
   "version": "0.0.0",
   "author": "Flip GmbH",
-  "engines": {
-    "node": "^14.17.0 || ^16.13.0 || ^18.17.0 || ^20.18.0"
-  },
   "workspaces": [
     "./packages/bridge",
     "./packages/swirl-components",

--- a/packages/swirl-components/src/components/swirl-carousel/swirl-carousel.tsx
+++ b/packages/swirl-components/src/components/swirl-carousel/swirl-carousel.tsx
@@ -74,6 +74,7 @@ export class SwirlCarousel {
   @Listen("resize", { target: "window" })
   onWindowResize() {
     this.checkScrollStatus();
+    this.checkScrollPosition();
   }
 
   componentDidLoad() {


### PR DESCRIPTION
[Ticket](https://linear.app/flip/issue/ENG-1258/new-highlights-dont-scroll-the-carousel-to-the-left)