### PR TITLE
Fix SwirlModal body scroll unlock exception

### DIFF
--- a/.changeset/nasty-rats-remain.md
+++ b/.changeset/nasty-rats-remain.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix exception caused by unlocking the swirl-modal body scroll

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
@@ -310,8 +310,13 @@ export class SwirlModal {
   }
 
   private unlockBodyScroll() {
-    enableBodyScroll(this.scrollContainer);
-    enableBodyScroll(this.sidebarScrollContainer);
+    if (this.scrollContainer) {
+      enableBodyScroll(this.scrollContainer);
+    }
+
+    if (this.sidebarScrollContainer) {
+      enableBodyScroll(this.sidebarScrollContainer);
+    }
   }
 
   render() {


### PR DESCRIPTION
Should fix this exception:
<img width="558" alt="Bildschirmfoto 2025-04-25 um 15 09 00" src="https://github.com/user-attachments/assets/a24bd9f4-6b9f-453b-912c-212bc4421459" />
