### PR TITLE
Hide closed SwirlPopovers entirely

### DIFF
--- a/.changeset/poor-walls-complain.md
+++ b/.changeset/poor-walls-complain.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Completely hide closed swirl-popovers to prevent them from messing with the
+layout flow"

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -46,6 +46,7 @@ jobs:
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "packages/swirl-components/storybook-static" # Built app content directory - optional
+          build_timeout_in_minutes: 60
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -30,8 +30,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Install dependencies
-        run: yarn install --verbose
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -35,6 +35,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
         with:
           azure_static_web_apps_api_token:
             ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_ICY_WATER_049EC4003 }}
@@ -46,7 +47,6 @@ jobs:
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "packages/swirl-components/storybook-static" # Built app content directory - optional
-          build_timeout_in_minutes: 60
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Install dependencies
+        run: yarn install --verbose
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1

--- a/packages/swirl-components/src/components/swirl-menu/swirl-menu.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-menu/swirl-menu.spec.tsx
@@ -83,7 +83,7 @@ describe("swirl-menu", () => {
             </button>
           </swirl-button>
         </swirl-popover-trigger>
-        <swirl-popover id="menu" label="Menu">
+        <swirl-popover id="menu" label="Menu" style="display: none;">
           <mock:shadow-root>
             <div class="popover popover--animation-scale-in-xy popover--inactive popover--padded popover--placement-undefined">
               <div aria-hidden="true" aria-label="Menu" class="popover__content" part="popover__content" role="dialog" tabindex="-1">

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.css
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.css
@@ -3,7 +3,6 @@
 :host {
   position: relative;
   z-index: var(--s-z-40);
-  display: inline-flex;
 
   & * {
     box-sizing: border-box;

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.spec.tsx
@@ -15,7 +15,7 @@ describe("swirl-popover", () => {
       <swirl-popover-trigger swirl-popover="popover">
         <button id="trigger">Trigger popover</button>
       </swirl-popover-trigger>
-      <swirl-popover label="Popover" id="popover">
+      <swirl-popover label="Popover" id="popover" style="display: none;">
         <div>Content</div>
       </swirl-popover>
     </div>
@@ -42,7 +42,7 @@ describe("swirl-popover", () => {
         <swirl-popover-trigger swirl-popover="popover">
           <button aria-controls="popover" aria-expanded="false" aria-haspopup="dialog" id="trigger">Trigger popover</button>
         </swirl-popover-trigger>
-        <swirl-popover id="popover" label="Popover">
+        <swirl-popover id="popover" label="Popover" style="display: none;">
           <mock:shadow-root>
             <div class="popover popover--animation-scale-in-xy popover--inactive popover--padded popover--placement-undefined">
               <div aria-hidden="true" aria-label="Popover" class="popover__content" part="popover__content" role="dialog" tabindex="-1">

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.tsx
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.tsx
@@ -399,7 +399,7 @@ export class SwirlPopover {
     );
 
     return (
-      <Host>
+      <Host style={{ display: this.active ? "inline-flex" : "none" }}>
         <div class={className} onKeyDown={this.onKeydown}>
           <div
             aria-hidden={!this.active ? "true" : "false"}


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-1691/save-button-moves-out-of-view-port-when-more-and-more-images-are)
- [Storybook](#)

The popover always had a `display: inline-flex` which could mess up the layout flow of pages, even when the popover was closed. This change applies `display: none` to closed popovers.