### PR TITLE
Fix yarn install in Github actions

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -30,11 +30,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+      - run: yarn install --ignore-scripts
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=8192"
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
         with:
           azure_static_web_apps_api_token:

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           submodules: true
       - run: yarn install --ignore-scripts
+      - run: npx turbo run build --filter=!swirl-docs
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -44,7 +45,7 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_build_command: "npx turbo run build --filter=!swirl-docs"
+          skip_app_build: true
           app_location: "/" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "packages/swirl-components/storybook-static" # Built app content directory - optional

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -36,7 +36,7 @@ jobs:
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
+          NODE_OPTIONS: "--max_old_space_size=4096"
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
         with:
           azure_static_web_apps_api_token:
@@ -46,7 +46,7 @@ jobs:
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           skip_app_build: true
-          app_location: "/" # App source code path
+          app_location: "packages/swirl-components/storybook-static" # App source code path
           api_location: "" # Api source code path - optional
           output_location: "packages/swirl-components/storybook-static" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-      - run: yarn
+      - run: yarn install --ignore-scripts
       - run: yarn build --filter=@getflip/swirl-tokens
       - run: npx turbo run prebuild # needed for swirl-docs tests
       - run: yarn lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: yarn
+      - run: yarn install --ignore-scripts
 
       - name: Publish to npm
         id: changesets
@@ -24,7 +24,7 @@ jobs:
         with:
           publish: yarn release
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=8192"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           publish: yarn release
         env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
+          NODE_OPTIONS: "--max_old_space_size=4096"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - run: yarn && yarn test:coverage
+      - run: yarn install --ignore-scripts && yarn test:coverage
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@master
         env:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare-dart-packages": "node packages/swirl-tokens/scripts/update-dart-package-version.js && node packages/swirl-icons/scripts/update-dart-package-version.js",
     "release": "turbo run build --filter=!swirl-docs && changeset publish",
     "preversion": "echo \"Error: use @changsets/cli to version packages\" && exit 1",
-    "postinstall": "patch-package"
+    "prebuild": "patch-package"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.4",

--- a/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.stories.ts
+++ b/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.stories.ts
@@ -26,13 +26,13 @@ const Template = (args) => {
   const element = generateStoryElement("swirl-action-list-item", args);
 
   element.innerHTML = `
-  <swirl-avatar
-    slot="avatar"
-    label="Jane Doe"
-    size="l"
-    src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a"></swirl-avatar>
-  <swirl-switch checked hide-label label="Test" slot="suffix"></swirl-switch>
-  `;
+<swirl-avatar
+  slot="avatar"
+  label="Jane Doe"
+  size="l"
+  src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a"></swirl-avatar>
+<swirl-switch checked hide-label label="Test" slot="suffix"></swirl-switch>
+`;
 
   return element;
 };

--- a/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.stories.ts
+++ b/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.stories.ts
@@ -26,13 +26,13 @@ const Template = (args) => {
   const element = generateStoryElement("swirl-action-list-item", args);
 
   element.innerHTML = `
-<swirl-avatar
-  slot="avatar"
-  label="Jane Doe"
-  size="l"
-  src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a"></swirl-avatar>
-<swirl-switch checked hide-label label="Test" slot="suffix"></swirl-switch>
-`;
+  <swirl-avatar
+    slot="avatar"
+    label="Jane Doe"
+    size="l"
+    src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a"></swirl-avatar>
+  <swirl-switch checked hide-label label="Test" slot="suffix"></swirl-switch>
+  `;
 
   return element;
 };


### PR DESCRIPTION
One of the post-install scripts (of a dependency) is timing out in Github actions, so I …

- added `yarn install --ignore-scripts` to the workflows
- moved the `patch-package` script from the `post-install` to the `prebuild` step

In my manual tests omitting the post-install scripts (other than `patch-package`) of the dependencies seemed fine. For the `publish` workflow we need to merge and check on main.

A nice side-effect: This speeds up the workflows by a lot.