### PR TITLE
EMP-257 Improve media query listeners

### DIFF
--- a/.changeset/spotty-ants-behave.md
+++ b/.changeset/spotty-ants-behave.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Improve the performance of desktop media queries

--- a/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-action-list-item/swirl-action-list-item.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, h, Host, Prop } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlActionListItemIntent = "default" | "critical";
 
@@ -30,34 +30,20 @@ export class SwirlActionListItem {
   @Prop() swirlAriaHaspopup?: string;
   @Prop() suffix?: string;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private iconEl: HTMLElement;
   private iconBadgeEl: HTMLElement;
   private suffixEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
-  }
-
-  componentDidRender() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     const icon = this.iconEl?.children[0];

--- a/packages/swirl-components/src/components/swirl-banner/swirl-banner.tsx
+++ b/packages/swirl-components/src/components/swirl-banner/swirl-banner.tsx
@@ -8,7 +8,7 @@ import {
   Prop,
 } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlBannerAriaRole = "alert" | "status";
 
@@ -50,29 +50,19 @@ export class SwirlBanner {
   @Event() action?: EventEmitter<MouseEvent>;
   @Event() dismiss?: EventEmitter<MouseEvent>;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private dismissButtonEl: HTMLElement;
   private iconEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     const icon = this.iconEl?.children[0];

--- a/packages/swirl-components/src/components/swirl-button/swirl-button.tsx
+++ b/packages/swirl-components/src/components/swirl-button/swirl-button.tsx
@@ -1,6 +1,6 @@
 import { Component, Element, h, Host, Prop } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlButtonIconPosition = "start" | "end";
 
@@ -67,34 +67,24 @@ export class SwirlButton {
   @Prop() inheritFontSize?: boolean;
 
   private buttonEl: HTMLElement;
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private iconEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
     this.updateFormAttribute();
 
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   componentDidRender() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
     this.updateFormAttribute();
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     if (!Boolean(this.iconEl)) {

--- a/packages/swirl-components/src/components/swirl-chip/swirl-chip.tsx
+++ b/packages/swirl-components/src/components/swirl-chip/swirl-chip.tsx
@@ -8,7 +8,7 @@ import {
   Prop,
 } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlChipBorderRadius = "pill" | "sm";
 
@@ -49,23 +49,17 @@ export class SwirlChip {
   @Event() chipClick: EventEmitter<MouseEvent>;
   @Event({ eventName: "remove" }) removeChip?: EventEmitter<MouseEvent>;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private iconEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
 
   private forceIconProps(smallIcon: boolean) {
@@ -78,10 +72,6 @@ export class SwirlChip {
 
     icon?.setAttribute("size", iconSize);
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   render() {
     const Tag =

--- a/packages/swirl-components/src/components/swirl-inline-error/swirl-inline-error.tsx
+++ b/packages/swirl-components/src/components/swirl-inline-error/swirl-inline-error.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Host, Prop } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlInlineErrorSize = "s" | "m";
 
@@ -13,28 +13,18 @@ export class SwirlInlineError {
   @Prop() message!: string;
   @Prop() size?: SwirlInlineErrorSize = "m";
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private iconEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     if (!Boolean(this.iconEl)) {

--- a/packages/swirl-components/src/components/swirl-inline-status/swirl-inline-status.tsx
+++ b/packages/swirl-components/src/components/swirl-inline-status/swirl-inline-status.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Host, Prop, State } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 import { SwirlIconSize } from "../swirl-icon/swirl-icon.types";
 
 export type SwirlInlineStatusIntent =
@@ -25,28 +25,18 @@ export class SwirlInlineStatus {
 
   @State() iconSize: SwirlIconSize = 20;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private iconEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     if (!Boolean(this.iconEl)) {

--- a/packages/swirl-components/src/components/swirl-option-list-item/swirl-option-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-option-list-item/swirl-option-list-item.tsx
@@ -10,7 +10,7 @@ import {
 } from "@stencil/core";
 import classnames from "classnames";
 import { v4 as uuid } from "uuid";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlOptionListItemContext = "single-select" | "multi-select";
 
@@ -48,31 +48,20 @@ export class SwirlOptionListItem {
   @State() iconSize: 20 | 24 = 24;
   @State() focused: boolean;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private iconEl: HTMLElement;
   private elementId = uuid();
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-    this.updateIconSize(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+      this.updateIconSize(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-    this.updateIconSize(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     const icon = this.iconEl?.children[0];

--- a/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.tsx
@@ -1,6 +1,6 @@
 import { Component, Event, EventEmitter, h, Host, Prop } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 @Component({
   scoped: true,
@@ -19,28 +19,18 @@ export class SwirlResourceListFileItem {
 
   @Event() remove: EventEmitter<MouseEvent>;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private iconEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     if (!Boolean(this.iconEl)) {

--- a/packages/swirl-components/src/components/swirl-search/swirl-search.tsx
+++ b/packages/swirl-components/src/components/swirl-search/swirl-search.tsx
@@ -8,7 +8,7 @@ import {
   Prop,
 } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlSearchVariant = "filled" | "outline";
 
@@ -40,17 +40,14 @@ export class SwirlSearch {
   @Event() inputInput: EventEmitter<string>;
   @Event() valueChange: EventEmitter<string>;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private input: HTMLInputElement;
   private iconEl: HTMLElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
 
     // see https://stackoverflow.com/a/27314017
     if (this.autoFocus) {
@@ -61,15 +58,8 @@ export class SwirlSearch {
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     if (!Boolean(this.iconEl)) {

--- a/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.tsx
+++ b/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.tsx
@@ -10,7 +10,8 @@ import {
   Watch,
 } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery, SwirlFormInput } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
+import { SwirlFormInput } from "../../utils";
 
 export type SwirlTextInputFontSize = "default" | "sm" | "base";
 
@@ -88,16 +89,13 @@ export class SwirlTextInput implements SwirlFormInput {
   @Event() inputFocus: EventEmitter<FocusEvent>;
   @Event() valueChange: EventEmitter<string>;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private inputEl: HTMLInputElement;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   componentDidLoad() {
-    this.updateIconSize(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.updateIconSize(isDesktop);
+    });
 
     // see https://stackoverflow.com/a/27314017
     if (this.autoFocus) {
@@ -112,10 +110,7 @@ export class SwirlTextInput implements SwirlFormInput {
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
 
   @Method()
@@ -134,10 +129,6 @@ export class SwirlTextInput implements SwirlFormInput {
       this.valueChange.emit(newValue);
     }
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.updateIconSize(event.matches);
-  };
 
   private updateIconSize(smallIcon: boolean) {
     this.iconSize = smallIcon ? 20 : 24;

--- a/packages/swirl-components/src/components/swirl-toast/swirl-toast.tsx
+++ b/packages/swirl-components/src/components/swirl-toast/swirl-toast.tsx
@@ -8,7 +8,7 @@ import {
   Watch,
 } from "@stencil/core";
 import classnames from "classnames";
-import { getDesktopMediaQuery } from "../../utils";
+import { DesktopMediaQuery } from "../../services/media-query.service";
 
 export type SwirlToastIntent = "default" | "critical" | "success";
 
@@ -28,10 +28,10 @@ export class SwirlToast {
 
   @Event() dismiss: EventEmitter<string>;
 
-  private desktopMediaQuery: MediaQueryList = getDesktopMediaQuery();
   private dismissIconEl: HTMLElement;
   private iconEl: HTMLElement;
   private timeout: NodeJS.Timeout;
+  private mediaQueryUnsubscribe: () => void = () => {};
 
   @Watch("duration")
   watchDuration() {
@@ -41,24 +41,14 @@ export class SwirlToast {
   componentDidLoad() {
     this.startTimer();
 
-    this.forceIconProps(this.desktopMediaQuery.matches);
-
-    this.desktopMediaQuery.addEventListener(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe = DesktopMediaQuery.subscribe((isDesktop) => {
+      this.forceIconProps(isDesktop);
+    });
   }
 
   disconnectedCallback() {
-    this.desktopMediaQuery.removeEventListener?.(
-      "change",
-      this.desktopMediaQueryHandler
-    );
+    this.mediaQueryUnsubscribe();
   }
-
-  private desktopMediaQueryHandler = (event: MediaQueryListEvent) => {
-    this.forceIconProps(event.matches);
-  };
 
   private forceIconProps(smallIcon: boolean) {
     const icon = this.iconEl?.children[0];

--- a/packages/swirl-components/src/services/media-query.service.ts
+++ b/packages/swirl-components/src/services/media-query.service.ts
@@ -1,0 +1,28 @@
+import { getDesktopMediaQuery } from "../utils";
+
+type CallbackFn = (isDesktop: boolean) => void;
+
+class DesktopMediaQueryService {
+  private mql: MediaQueryList;
+  private listeners = new Set<CallbackFn>();
+
+  constructor() {
+    this.mql = getDesktopMediaQuery();
+    this.mql.addEventListener("change", this.onChange);
+  }
+
+  private onChange = (e: MediaQueryListEvent) => {
+    this.listeners.forEach((callback) => callback(e.matches));
+  };
+
+  public subscribe(callback: CallbackFn): () => void {
+    this.listeners.add(callback);
+    callback(this.mql.matches);
+
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+}
+
+export const DesktopMediaQuery = new DesktopMediaQueryService();


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/EMP-257/swirl-refactor-desktopmediaquery-listeners)

We were registering way too many media query listeners; when I did some tests the number was around ~550 of them when on the newsfeed on `master`.
This approach only registers one native event listener, and our logic is in a single place that gives us full control.
Additionally, whenever you subscribe to the service you immediately get the current value, so components only need to subscribe to it and respond to the changes.

Additionally, icons used to flicker as described here https://linear.app/flip/issue/EMPWEB-12/tasks-icons-flickers-when-you-navigate-to-the-page
This doesn't seem to be the case anymore after this.