### PR TITLE
Fix collapse behavior of swirl-table-row-group

### DIFF
--- a/.changeset/honest-guests-dance.md
+++ b/.changeset/honest-guests-dance.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Fix swirl-table-row-group collapse

--- a/packages/swirl-components/src/components/swirl-table-row-group/swirl-table-row-group.css
+++ b/packages/swirl-components/src/components/swirl-table-row-group/swirl-table-row-group.css
@@ -49,7 +49,7 @@
 }
 
 .table-row-group__rows-container {
-  display: contents;
+  overflow: visible clip;
   transition: height 0.3s ease-out;
 }
 


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/EMPWEB-67/section-collapse-is-not-working-menu-items-admin-console)

The collapse of swirl-table-row-group did not work due to the change here https://github.com/getflip/swirl/pull/770/files.
Since it sets the height to 0 it needs an `overflow: hidden`. Height 0 will not work with `display: contents`, and a simple `overflow: hidden` would break our sticky column logic. Only thing that worked is `visible` for the x-axis, and `clip` for the y-axis