### PR TITLE
Fix SwirlModal max width …

### DIFF
--- a/.changeset/dry-bears-chew.md
+++ b/.changeset/dry-bears-chew.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix swirl-modal max width when used with sidebar or secondary content

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
@@ -213,7 +213,8 @@
 }
 
 .modal--has-secondary-content {
-  &:not(.modal--fullscreen) .modal__body {
+  &.modal.modal--variant-default:not(.modal--fullscreen) .modal__body,
+  &.modal.modal--variant-drawer:not(.modal--fullscreen) .modal__body {
     max-width: calc(
       var(--swirl-modal-max-width) +
         var(--swirl-modal-max-secondary-content-width)
@@ -277,12 +278,14 @@
   display: none;
 }
 
-.modal--has-sidebar-content {
-  &:not(.modal--fullscreen) .modal__body {
+.modal.modal--has-sidebar-content {
+  &.modal.modal--variant-default:not(.modal--fullscreen) .modal__body,
+  &.modal.modal--variant-drawer:not(.modal--fullscreen) .modal__body {
     max-width: calc(
       var(--swirl-modal-max-width) + var(--swirl-modal-sidebar-width)
     );
   }
+
   @media (--from-tablet) {
     & .modal__sidebar {
       display: flex;
@@ -421,7 +424,8 @@
 }
 
 .modal--fullscreen-transitioning .modal__body {
-  transition: width 0.15s ease-out, max-width 0.15s ease-out, max-height 0.15s ease-out, min-height 0.15s ease-out;
+  transition: width 0.15s ease-out, max-width 0.15s ease-out,
+    max-height 0.15s ease-out, min-height 0.15s ease-out;
 }
 
 .modal.modal--variant-default:not(.modal--fullscreen) {


### PR DESCRIPTION
…when used with sidebar or secondary content

## Summary

- [Ticket](https://linear.app/flip/issue/ENG-1951/left-side-of-the-add-user-groups-tab-is-too-small)
