### PR TITLE
Fix PDF printing crashes

### DIFF
--- a/.changeset/itchy-months-sin.md
+++ b/.changeset/itchy-months-sin.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Prevent PDF printing of high-res files to crash the browser

--- a/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-pdf/swirl-file-viewer-pdf.tsx
+++ b/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-pdf/swirl-file-viewer-pdf.tsx
@@ -272,7 +272,7 @@ export class SwirlFileViewerPdf {
 
     this.renderingPageNumbers = [...this.renderingPageNumbers, page.pageNumber];
 
-    const scale = forPrint ? 2 : this.getScale(page);
+    const scale = forPrint ? this.getPrintScale(page) : this.getScale(page);
     const outputScale = window.devicePixelRatio || 1;
 
     const transform =
@@ -463,6 +463,14 @@ export class SwirlFileViewerPdf {
     }
 
     return this.zoom;
+  }
+
+  private getPrintScale(page: PDFPageProxy) {
+    // For performance reasons we have to limit the print scale. The resulting
+    // width of a page should not exceed 2480px in width, and 3508px in height.
+    // This relates to the maximum resolution of an A4 page at 300 DPI, which
+    // should be sufficient for a decent print quality.
+    return Math.min(Math.min(2480 / page.view[2], 3508 / page.view[3]), 2);
   }
 
   private restoreScrollPosition() {


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-1949/kb-pdf-preview-print-pdf-breaks-the-website)
