### PR TITLE
Add alternative "list" semantics to SwirlResourceList and SwirlTreeView

### DIFF
--- a/.changeset/fresh-moons-explain.md
+++ b/.changeset/fresh-moons-explain.md
@@ -4,4 +4,5 @@
 "@getflip/swirl-components-react": minor
 ---
 
-Allow swirl-resource-list to use "list" semantics (instead of "grid")
+Allow swirl-resource-list and swirl-tree-view to use "list" semantics (instead
+of "grid"/"tree")

--- a/.changeset/fresh-moons-explain.md
+++ b/.changeset/fresh-moons-explain.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Allow swirl-resource-list to use "list" semantics (instead of "grid")

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -51,7 +51,7 @@ import { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover"
 import { ComputePositionReturn, Placement, Strategy } from "@floating-ui/dom";
 import { SwirlProgressIndicatorSize, SwirlProgressIndicatorVariant } from "./components/swirl-progress-indicator/swirl-progress-indicator";
 import { SwirlRadioState, SwirlRadioVariant } from "./components/swirl-radio/swirl-radio";
-import { SwirlBoxPadding as SwirlBoxPadding1 } from "./components/swirl-resource-list/swirl-resource-list";
+import { SwirlBoxPadding as SwirlBoxPadding1, SwirlResourceListSemantics } from "./components/swirl-resource-list/swirl-resource-list";
 import { SwirlResourceListItemLabelWeight } from "./components/swirl-resource-list-item/swirl-resource-list-item";
 import { SwirlSearchVariant } from "./components/swirl-search/swirl-search";
 import { SwirlSeparatorColor, SwirlSeparatorOrientation, SwirlSeparatorSpacing as SwirlSeparatorSpacing1 } from "./components/swirl-separator/swirl-separator";
@@ -127,7 +127,7 @@ export { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover"
 export { ComputePositionReturn, Placement, Strategy } from "@floating-ui/dom";
 export { SwirlProgressIndicatorSize, SwirlProgressIndicatorVariant } from "./components/swirl-progress-indicator/swirl-progress-indicator";
 export { SwirlRadioState, SwirlRadioVariant } from "./components/swirl-radio/swirl-radio";
-export { SwirlBoxPadding as SwirlBoxPadding1 } from "./components/swirl-resource-list/swirl-resource-list";
+export { SwirlBoxPadding as SwirlBoxPadding1, SwirlResourceListSemantics } from "./components/swirl-resource-list/swirl-resource-list";
 export { SwirlResourceListItemLabelWeight } from "./components/swirl-resource-list-item/swirl-resource-list-item";
 export { SwirlSearchVariant } from "./components/swirl-search/swirl-search";
 export { SwirlSeparatorColor, SwirlSeparatorOrientation, SwirlSeparatorSpacing as SwirlSeparatorSpacing1 } from "./components/swirl-separator/swirl-separator";
@@ -3384,6 +3384,10 @@ export namespace Components {
         "paddingInlineEnd"?: SwirlBoxPadding1;
         "paddingInlineStart"?: SwirlBoxPadding1;
         /**
+          * @default "grid"
+         */
+        "semantics"?: SwirlResourceListSemantics;
+        /**
           * @default "0"
          */
         "spacing"?: SwirlStackSpacing;
@@ -3681,6 +3685,7 @@ export namespace Components {
           * @default "0"
          */
         "spacing"?: SwirlStackSpacing1;
+        "swirlAriaRole"?: string;
         /**
           * @default false
          */
@@ -11345,6 +11350,10 @@ declare namespace LocalJSX {
         "paddingInlineEnd"?: SwirlBoxPadding1;
         "paddingInlineStart"?: SwirlBoxPadding1;
         /**
+          * @default "grid"
+         */
+        "semantics"?: SwirlResourceListSemantics;
+        /**
           * @default "0"
          */
         "spacing"?: SwirlStackSpacing;
@@ -11645,6 +11654,7 @@ declare namespace LocalJSX {
           * @default "0"
          */
         "spacing"?: SwirlStackSpacing1;
+        "swirlAriaRole"?: string;
         /**
           * @default false
          */

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -78,7 +78,7 @@ import { SwirlToastConfig, SwirlToastMessage } from "./components/swirl-toast-pr
 import { SwirlToggleGroupVariant } from "./components/swirl-toggle-group/swirl-toggle-group";
 import { SwirlToolbarOrientation } from "./components/swirl-toolbar/swirl-toolbar";
 import { SwirlTooltipPosition } from "./components/swirl-tooltip/swirl-tooltip";
-import { SwirlTreeViewCanDropHandler, SwirlTreeViewDropItemEvent } from "./components/swirl-tree-view/swirl-tree-view";
+import { SwirlTreeViewCanDropHandler, SwirlTreeViewDropItemEvent, SwirlTreeViewSemantics } from "./components/swirl-tree-view/swirl-tree-view";
 import { SwirlTreeViewDropItemEvent as SwirlTreeViewDropItemEvent1 } from "./components/swirl-tree-view/swirl-tree-view";
 import { SwirlTreeViewItemKeyboardMoveEvent } from "./components/swirl-tree-view-item/swirl-tree-view-item";
 export { SwirlHeadingLevel } from "./components/swirl-heading/swirl-heading";
@@ -154,7 +154,7 @@ export { SwirlToastConfig, SwirlToastMessage } from "./components/swirl-toast-pr
 export { SwirlToggleGroupVariant } from "./components/swirl-toggle-group/swirl-toggle-group";
 export { SwirlToolbarOrientation } from "./components/swirl-toolbar/swirl-toolbar";
 export { SwirlTooltipPosition } from "./components/swirl-tooltip/swirl-tooltip";
-export { SwirlTreeViewCanDropHandler, SwirlTreeViewDropItemEvent } from "./components/swirl-tree-view/swirl-tree-view";
+export { SwirlTreeViewCanDropHandler, SwirlTreeViewDropItemEvent, SwirlTreeViewSemantics } from "./components/swirl-tree-view/swirl-tree-view";
 export { SwirlTreeViewDropItemEvent as SwirlTreeViewDropItemEvent1 } from "./components/swirl-tree-view/swirl-tree-view";
 export { SwirlTreeViewItemKeyboardMoveEvent } from "./components/swirl-tree-view-item/swirl-tree-view-item";
 export namespace Components {
@@ -4498,6 +4498,10 @@ export namespace Components {
         "expandItems": (itemIds: string[]) => Promise<void>;
         "initiallyExpandedItemIds"?: string[];
         "label": string;
+        /**
+          * @default "tree"
+         */
+        "semantics"?: SwirlTreeViewSemantics;
     }
     interface SwirlTreeViewItem {
         "active"?: boolean;
@@ -12439,6 +12443,10 @@ declare namespace LocalJSX {
     itemId: string;
     expanded: boolean;
   }>) => void;
+        /**
+          * @default "tree"
+         */
+        "semantics"?: SwirlTreeViewSemantics;
     }
     interface SwirlTreeViewItem {
         "active"?: boolean;

--- a/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.spec.tsx
@@ -7,11 +7,13 @@ describe("swirl-resource-list-file-item", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListFileItem],
       html: `
-        <swirl-resource-list-file-item
-          description="Description"
-          label="Label"
-          loading="true"
-        ></swirl-resource-list-file-item>
+        <div role="grid">
+          <swirl-resource-list-file-item
+            description="Description"
+            label="Label"
+            loading="true"
+          ></swirl-resource-list-file-item>
+        </div>
       `,
     });
 

--- a/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-file-item/swirl-resource-list-file-item.tsx
@@ -1,4 +1,12 @@
-import { Component, Event, EventEmitter, h, Host, Prop } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+} from "@stencil/core";
 import classnames from "classnames";
 import { DesktopMediaQuery } from "../../services/media-query.service";
 
@@ -9,6 +17,8 @@ import { DesktopMediaQuery } from "../../services/media-query.service";
   tag: "swirl-resource-list-file-item",
 })
 export class SwirlResourceListFileItem {
+  @Element() el: HTMLSwirlResourceListFileItemElement;
+
   @Prop() description?: string;
   @Prop() errorMessage?: string;
   @Prop() icon?: string = "<swirl-icon-file></swirl-icon-file>";
@@ -48,13 +58,20 @@ export class SwirlResourceListFileItem {
     const showSpinner = !showError && this.loading;
     const showRemoveButton = this.removable && !showSpinner;
 
+    const hostRole = !!this.el.closest('[role="grid"]') ? "row" : "listitem";
+    const containerRole = hostRole === "row" ? "gridcell" : undefined;
+
     const className = classnames("resource-list-file-item", {
       "resource-list-file-item--has-control": showSpinner || showRemoveButton,
     });
 
     return (
-      <Host role="row">
-        <div class={className} part="resource-list-file-item" role="gridcell">
+      <Host role={hostRole}>
+        <div
+          class={className}
+          part="resource-list-file-item"
+          role={containerRole}
+        >
           <span
             class="resource-list-file-item__icon"
             innerHTML={this.icon}

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.spec.tsx
@@ -7,12 +7,14 @@ describe("swirl-resource-list-item", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListItem],
       html: `
-        <swirl-resource-list-item
-          description="Description"
-          label="Label"
-        >
-          <swirl-avatar label="John Doe" src="https://picsum.photos/id/433/144/144" slot="media"></swirl-avatar>
-        </swirl-resource-list-item>
+        <div role="grid">
+          <swirl-resource-list-item
+            description="Description"
+            label="Label"
+          >
+            <swirl-avatar label="John Doe" src="https://picsum.photos/id/433/144/144" slot="media"></swirl-avatar>
+          </swirl-resource-list-item>
+        </div>
       `,
     });
 
@@ -44,7 +46,9 @@ describe("swirl-resource-list-item", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListItem],
       html: `
-        <swirl-resource-list-item href="#" label="Label"></swirl-resource-list-item>
+        <div role="grid">
+          <swirl-resource-list-item href="#" label="Label"></swirl-resource-list-item>
+        </div>
       `,
     });
 
@@ -58,7 +62,9 @@ describe("swirl-resource-list-item", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListItem],
       html: `
-        <swirl-resource-list-item label="Label" selectable="true"></swirl-resource-list-item>
+        <div role="grid">
+          <swirl-resource-list-item label="Label" selectable="true"></swirl-resource-list-item>
+        </div>
       `,
     });
 
@@ -88,7 +94,9 @@ describe("swirl-resource-list-item", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListItem],
       html: `
-        <swirl-resource-list-item label="Label" meta="Meta"></swirl-resource-list-item>
+        <div role="grid">
+          <swirl-resource-list-item label="Label" meta="Meta"></swirl-resource-list-item>
+        </div>
       `,
     });
 
@@ -99,9 +107,11 @@ describe("swirl-resource-list-item", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListItem],
       html: `
-        <swirl-resource-list-item label="Label">
-          <swirl-button label="Label" slot="control"></swirl-button>
-        </swirl-resource-list-item>
+        <div role="grid">
+          <swirl-resource-list-item label="Label">
+            <swirl-button label="Label" slot="control"></swirl-button>
+          </swirl-resource-list-item>
+        </div>
       `,
     });
 
@@ -113,7 +123,11 @@ describe("swirl-resource-list-item", () => {
   it("can be draggable", async () => {
     const page = await newSpecPage({
       components: [SwirlResourceListItem],
-      html: `<swirl-resource-list-item allow-drag="true" label="Resource List Item"></swirl-resource-list-item>`,
+      html: `
+        <div role="grid">
+          <swirl-resource-list-item allow-drag="true" label="Resource List Item"></swirl-resource-list-item>
+        </div>
+      `,
     });
 
     const spy = jest.fn();
@@ -139,8 +153,9 @@ describe("swirl-resource-list-item", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListItem],
       html: `
-        <swirl-resource-list-item label="<button>Button</button>" allow-html="false" description="<button>Description</button>">
-        </swirl-resource-list-item>
+        <div role="grid">
+          <swirl-resource-list-item label="<button>Button</button>" allow-html="false" description="<button>Description</button>"></swirl-resource-list-item>
+        </div>
       `,
     });
 

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
@@ -195,6 +195,8 @@ export class SwirlResourceListItem {
       : this.label;
     const ariaChecked = this.selectable ? String(this.checked) : undefined;
     const role = this.interactive && this.selectable ? "checkbox" : undefined;
+    const hostRole = !!this.el.closest('[role="grid"]') ? "row" : "listitem";
+    const containerRole = hostRole === "row" ? "gridcell" : undefined;
 
     const labelContainerStyles = {
       paddingRight:
@@ -228,8 +230,8 @@ export class SwirlResourceListItem {
     );
 
     return (
-      <Host role="row">
-        <div class={className} role="gridcell">
+      <Host role={hostRole}>
+        <div class={className} role={containerRole}>
           <Tag
             aria-checked={ariaChecked}
             aria-disabled={disabled ? "true" : undefined}

--- a/packages/swirl-components/src/components/swirl-resource-list-section/swirl-resource-list-section.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-section/swirl-resource-list-section.spec.tsx
@@ -7,10 +7,12 @@ describe("swirl-resource-list-section", () => {
     const page = await newSpecPage({
       components: [SwirlResourceListSection],
       html: `
-        <swirl-resource-list-section label="Resource section!">
-          <swirl-resource-list-item label="Item #1"></swirl-resource-list-item>
-          <swirl-resource-list-item label="Item #2"></swirl-resource-list-item>
-        </swirl-resource-list-section>
+        <div role="grid">
+          <swirl-resource-list-section label="Resource section!">
+            <swirl-resource-list-item label="Item #1"></swirl-resource-list-item>
+            <swirl-resource-list-item label="Item #2"></swirl-resource-list-item>
+          </swirl-resource-list-section>
+        </div>
       `,
     });
 

--- a/packages/swirl-components/src/components/swirl-resource-list-section/swirl-resource-list-section.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-section/swirl-resource-list-section.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, Prop } from "@stencil/core";
+import { Component, Element, h, Host, Prop } from "@stencil/core";
 import { SwirlSeparatorSpacing } from "../swirl-separator/swirl-separator";
 import { SwirlStackSpacing } from "../swirl-stack/swirl-stack";
 
@@ -11,18 +11,23 @@ import { SwirlStackSpacing } from "../swirl-stack/swirl-stack";
   tag: "swirl-resource-list-section",
 })
 export class SwirlResourceListSection {
+  @Element() el: HTMLSwirlResourceListSectionElement;
+
   @Prop() label!: string;
   @Prop() separatorSpacing?: SwirlSeparatorSpacing = "4";
   @Prop() spacing?: SwirlStackSpacing = "0";
   @Prop() hasSeparator?: boolean = false;
 
   render() {
+    const role = !!this.el.closest('[role="grid"]') ? "rowgroup" : "listitem";
+    const childrenListRole = role === "listitem" ? "list" : undefined;
+
     return (
       <Host>
         {this.hasSeparator && (
           <swirl-separator spacing={this.separatorSpacing}></swirl-separator>
         )}
-        <div aria-labelledby="label" role="rowgroup">
+        <div aria-labelledby="label" role={role}>
           <span
             id="label"
             class="resource-list-section-label"
@@ -31,7 +36,7 @@ export class SwirlResourceListSection {
             {this.label}
           </span>
 
-          <swirl-stack spacing={this.spacing}>
+          <swirl-stack spacing={this.spacing} swirlAriaRole={childrenListRole}>
             <slot></slot>
           </swirl-stack>
         </div>

--- a/packages/swirl-components/src/components/swirl-resource-list/swirl-resource-list.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list/swirl-resource-list.spec.tsx
@@ -68,6 +68,24 @@ describe("swirl-resource-list", () => {
     `);
   });
 
+  it("renders with list semantics", async () => {
+    const page = await newSpecPage({
+      components: [SwirlResourceList, SwirlResourceListItem],
+      html: `
+        <swirl-resource-list label="Label" semantics="list">
+          <swirl-resource-list-item label="This is a resource item"></swirl-resource-list-item>
+          <swirl-resource-list-item label="This is a resource item"></swirl-resource-list-item>
+        </swirl-resource-list>
+      `,
+    });
+
+    expect(page.root.querySelector('[role="list"]')).toBeDefined();
+    expect(page.root.querySelectorAll('[role="listitem"]')).toHaveLength(2);
+    expect(
+      page.root.querySelectorAll('[role="row"], [role="gridcell"]')
+    ).toHaveLength(0);
+  });
+
   it("manages focus via keyboard events", async () => {
     const page = await newSpecPage({
       components: [SwirlResourceList, SwirlResourceListItem],

--- a/packages/swirl-components/src/components/swirl-resource-list/swirl-resource-list.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list/swirl-resource-list.tsx
@@ -331,19 +331,17 @@ export class SwirlResourceList {
             : this.focusedIndex - 1;
 
         this.focusItemAtIndex(prevIndex);
-      } else if (event.code === "Space" || event.code === "Enter") {
-        if (Boolean(this.controllingElement) && event.code === "Enter") {
-          const item = this.items[this.focusedIndex];
+      } else if (event.code === "Enter" && Boolean(this.controllingElement)) {
+        const item = this.items[this.focusedIndex];
 
-          if (!Boolean(item) || !item.isConnected) {
-            return;
-          }
-
-          event.stopPropagation();
-          event.preventDefault();
-
-          item.click();
+        if (!Boolean(item) || !item.isConnected) {
+          return;
         }
+
+        event.stopPropagation();
+        event.preventDefault();
+
+        item.click();
       } else if (event.code === "Home") {
         event.preventDefault();
         this.focusItemAtIndex(0);

--- a/packages/swirl-components/src/components/swirl-stack/swirl-stack.tsx
+++ b/packages/swirl-components/src/components/swirl-stack/swirl-stack.tsx
@@ -45,6 +45,7 @@ export class SwirlStack {
   @Prop() columnSpacing?: SwirlStackSpacing;
   @Prop() rowSpacing?: SwirlStackSpacing;
   @Prop() spacing?: SwirlStackSpacing = "0";
+  @Prop() swirlAriaRole?: string;
   @Prop() wrap?: boolean = false;
 
   render() {
@@ -64,7 +65,7 @@ export class SwirlStack {
 
     return (
       <Host style={{ height: this.height }}>
-        <Tag class={className} style={styles}>
+        <Tag class={className} role={this.swirlAriaRole} style={styles}>
           <slot></slot>
         </Tag>
       </Host>

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.spec.tsx
@@ -6,7 +6,11 @@ describe("swirl-tree-view-item", () => {
   it("renders label and ID", async () => {
     const page = await newSpecPage({
       components: [SwirlTreeViewItem],
-      html: `<swirl-tree-view-item item-id="item" label="Label"></swirl-tree-view-item>`,
+      html: `
+        <div role="tree">
+          <swirl-tree-view-item item-id="item" label="Label"></swirl-tree-view-item>
+        </div>
+      `,
     });
 
     expect(page.root).toMatchInlineSnapshot(`
@@ -30,10 +34,12 @@ describe("swirl-tree-view-item", () => {
     const page = await newSpecPage({
       components: [SwirlTreeViewItem],
       html: `
-        <swirl-tree-view-item itemId="1" label="Label">
-          <swirl-tree-view-item itemId="2" label="Label"></swirl-tree-view-item>
-          <swirl-tree-view-item itemId="3" label="Label"></swirl-tree-view-item>
-        </swirl-tree-view-item>
+        <div role="tree">
+          <swirl-tree-view-item itemId="1" label="Label">
+            <swirl-tree-view-item itemId="2" label="Label"></swirl-tree-view-item>
+            <swirl-tree-view-item itemId="3" label="Label"></swirl-tree-view-item>
+          </swirl-tree-view-item>
+        </div>
       `,
     });
 
@@ -62,7 +68,9 @@ describe("swirl-tree-view-item", () => {
     const page = await newSpecPage({
       components: [SwirlTreeViewItem],
       html: `
-        <swirl-tree-view-item itemId="1" label="Label"></swirl-tree-view-item>
+        <div role="tree">
+          <swirl-tree-view-item itemId="1" label="Label"></swirl-tree-view-item>
+        </div>
       `,
     });
 

--- a/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.spec.tsx
@@ -191,4 +191,21 @@ describe("swirl-tree-view", () => {
       </swirl-tree-view>
     `);
   });
+
+  it("renders with list semantics", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTreeView, SwirlTreeViewItem],
+      html: `
+          <swirl-tree-view label="Label" semantics="list">
+            <swirl-tree-view-item label="This is a resource item"></swirl-tree-view-item>
+            <swirl-tree-view-item label="This is a resource item"></swirl-tree-view-item>
+          </swirl-tree-view>
+        `,
+    });
+
+    expect(page.root.querySelector("ul")).toBeDefined();
+    expect(page.root.querySelector('ul[role="tree"]')).toBeNull();
+    expect(page.root.querySelectorAll("li")).toHaveLength(2);
+    expect(page.root.querySelectorAll('li[role="treeitem"]')).toHaveLength(0);
+  });
 });

--- a/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.tsx
@@ -16,6 +16,8 @@ import Sortable, { SortableEvent } from "sortablejs";
 import { SwirlTreeViewItemKeyboardMoveEvent } from "../swirl-tree-view-item/swirl-tree-view-item";
 import { treeViewDragDropConfig } from "./swirl-tree-view.config";
 
+export type SwirlTreeViewSemantics = "tree" | "list";
+
 export type SwirlTreeViewDropItemEvent = Pick<
   SortableEvent,
   "oldIndex" | "newIndex" | "item"
@@ -60,6 +62,7 @@ export class SwirlTreeView {
   @Prop() enableDragDrop?: boolean;
   @Prop() initiallyExpandedItemIds?: string[];
   @Prop() label!: string;
+  @Prop() semantics?: SwirlTreeViewSemantics = "tree";
 
   @Event() dropItem!: EventEmitter<SwirlTreeViewDropItemEvent>;
   @Event() itemExpansionChanged!: EventEmitter<{
@@ -92,6 +95,10 @@ export class SwirlTreeView {
 
   @Method()
   async expandItems(itemIds: string[]) {
+    if (this.semantics !== "tree") {
+      return;
+    }
+
     const items = this.getItems().filter((item) =>
       itemIds.includes(item.itemId)
     );
@@ -133,6 +140,10 @@ export class SwirlTreeView {
 
   @Listen("keydown")
   onKeyDown(event: KeyboardEvent) {
+    if (this.semantics !== "tree") {
+      return;
+    }
+
     if (event.key === "ArrowDown") {
       event.preventDefault();
       this.selectNextItem();
@@ -191,6 +202,10 @@ export class SwirlTreeView {
   }
 
   private init() {
+    if (this.semantics !== "tree") {
+      return;
+    }
+
     const selectedItem = this.getSelectedItem();
     const allItems = this.getItems();
 
@@ -510,7 +525,7 @@ export class SwirlTreeView {
           class="tree-view"
           onFocusin={this.onFocus}
           onFocusout={this.onBlur}
-          role="tree"
+          role={this.semantics === "tree" ? "tree" : undefined}
           ref={(el) => (this.listElement = el)}
           tabIndex={-1}
         >

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -21054,6 +21054,18 @@
         {
           "name": "label",
           "description": ""
+        },
+        {
+          "name": "semantics",
+          "description": "",
+          "values": [
+            {
+              "name": "list"
+            },
+            {
+              "name": "tree"
+            }
+          ]
         }
       ]
     },

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -17793,6 +17793,18 @@
           ]
         },
         {
+          "name": "semantics",
+          "description": "",
+          "values": [
+            {
+              "name": "grid"
+            },
+            {
+              "name": "list"
+            }
+          ]
+        },
+        {
           "name": "spacing",
           "description": "",
           "values": [
@@ -18737,6 +18749,10 @@
               "name": "8"
             }
           ]
+        },
+        {
+          "name": "swirl-aria-role",
+          "description": ""
         },
         {
           "name": "wrap",


### PR DESCRIPTION
**Resource list:**
- new prop `semantics: 'grid' | 'list'` on swirl-resource-list
- list semantics disable custom keyboard controls and set role to "list"
- items adjust their roles automatically (`row` and `gridcell` to `listitem`)
- swirl-resource-list-section  poses as a `listitem` with a nested child list when list semantics are used

**Tree view:**
- new prop `semantics: 'tree' | 'list'` on swirl-tree-view
- list semantics disable custom keyboard controls and set role to "list"
- list semantics disable expanding/collapsing items
- items adjust their roles automatically (`treeitem` to `listitem`)