### PR TITLE
EMPWEB-81 Fix swirl-button outline issue

### DIFF
--- a/.changeset/perfect-pigs-matter.md
+++ b/.changeset/perfect-pigs-matter.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix swirl-button outline issue

--- a/packages/swirl-components/src/components/swirl-button/swirl-button.css
+++ b/packages/swirl-components/src/components/swirl-button/swirl-button.css
@@ -56,10 +56,6 @@
     }
   }
 
-  &:focus:where(:not(:focus-visible)) {
-    outline: none;
-  }
-
   &:focus-visible {
     outline-color: var(--s-focus-default);
     outline-offset: var(--s-space-2);


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/EMPWEB-81/swirl-button-with-variantoutline-loses-the-outline-when-focused)