### PR TITLE
EMPWEB-39 Add option to allow resource-list-item content, hide header border for scrolled modal

### DIFF
--- a/.changeset/two-spoons-hope.md
+++ b/.changeset/two-spoons-hope.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Add option to align swirl-resource-list-item content and hide modal header
+border when scrolled

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -3428,6 +3428,7 @@ export namespace Components {
     }
     interface SwirlResourceListItem {
         "active"?: boolean;
+        "alignItems"?: string;
         "allowDrag"?: boolean;
         /**
           * @default true
@@ -11429,6 +11430,7 @@ declare namespace LocalJSX {
     }
     interface SwirlResourceListItem {
         "active"?: boolean;
+        "alignItems"?: string;
         "allowDrag"?: boolean;
         /**
           * @default true

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -3020,6 +3020,7 @@ export namespace Components {
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
+        "hideScrolledHeaderBorder"?: boolean;
         "hideSecondaryContent"?: boolean;
         "hideSecondaryContentBorders"?: boolean;
         "hideSidebarContent"?: boolean;
@@ -11022,6 +11023,7 @@ declare namespace LocalJSX {
         "height"?: string;
         "hideCloseButton"?: boolean;
         "hideLabel"?: boolean;
+        "hideScrolledHeaderBorder"?: boolean;
         "hideSecondaryContent"?: boolean;
         "hideSecondaryContentBorders"?: boolean;
         "hideSidebarContent"?: boolean;

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.css
@@ -340,7 +340,7 @@
   }
 }
 
-.modal--scrolled {
+.modal--scrolled:not(.modal--hide-scrolled-header-border) {
   @media (--from-tablet) {
     &:not(.modal--has-header-tools) .modal__header {
       border-bottom-color: var(--s-border-default);

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
@@ -78,6 +78,7 @@ export class SwirlModal {
   @Prop({ mutable: true }) hideSidebarContent?: boolean;
   @Prop() hasSidebarCloseButton?: boolean;
   @Prop() sidebarCloseButtonLabel?: string = "Close sidebar";
+  @Prop() hideScrolledHeaderBorder?: boolean;
 
   @Event() toggleFullscreen: EventEmitter<boolean>;
   @Event() modalClose: EventEmitter<void>;
@@ -365,6 +366,7 @@ export class SwirlModal {
       "modal--padded": this.padded,
       "modal--scrollable": this.scrollable,
       "modal--scrolled": this.scrolled,
+      "modal--hide-scrolled-header-border": this.hideScrolledHeaderBorder,
       "modal--scrolled-down": this.scrolledDown,
       "modal--hide-secondary-content-borders": this.hideSecondaryContentBorders,
       "modal--has-sidebar-content":

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
@@ -57,6 +57,7 @@ export class SwirlResourceListItem {
   @Prop() selectable?: boolean;
   @Prop() swirlAriaLabel?: string;
   @Prop() value?: string;
+  @Prop() alignItems?: string;
 
   @State() hasMedia: boolean = false;
   @State() iconSize: 20 | 24 = 24;
@@ -240,6 +241,7 @@ export class SwirlResourceListItem {
               Boolean(this.swirlAriaLabel) ? undefined : this.elementId
             }
             class="resource-list-item__content"
+            style={{ alignItems: this.alignItems }}
             href={href}
             disabled={disabled}
             onClick={this.onClick}

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -18018,6 +18018,10 @@
           "description": ""
         },
         {
+          "name": "align-items",
+          "description": ""
+        },
+        {
           "name": "allow-drag",
           "description": ""
         },

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -16848,6 +16848,10 @@
           "description": ""
         },
         {
+          "name": "hide-scrolled-header-border",
+          "description": ""
+        },
+        {
           "name": "hide-secondary-content",
           "description": ""
         },


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/EMPWEB-39/show-event-participants-grouped-by-rsvp-response-on-web)