### PR TITLE
feat(components): make SwirlPopover a valid value for SwirlPopoverTri…

### DIFF
--- a/.changeset/metal-balloons-refuse.md
+++ b/.changeset/metal-balloons-refuse.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Allow to pass SwirlPopover component instances as the "swirlPopover" prop of the
+swirl-popover-trigger

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -49,6 +49,7 @@ import { SwirlOptionListItemContext, SwirlOptionListItemRole } from "./component
 import { SwirlPaginationVariant } from "./components/swirl-pagination/swirl-pagination";
 import { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover";
 import { ComputePositionReturn, Placement, Strategy } from "@floating-ui/dom";
+import { SwirlPopover } from "./components/swirl-popover/swirl-popover";
 import { SwirlProgressIndicatorSize, SwirlProgressIndicatorVariant } from "./components/swirl-progress-indicator/swirl-progress-indicator";
 import { SwirlRadioState, SwirlRadioVariant } from "./components/swirl-radio/swirl-radio";
 import { SwirlBoxPadding as SwirlBoxPadding1, SwirlResourceListSemantics } from "./components/swirl-resource-list/swirl-resource-list";
@@ -125,6 +126,7 @@ export { SwirlOptionListItemContext, SwirlOptionListItemRole } from "./component
 export { SwirlPaginationVariant } from "./components/swirl-pagination/swirl-pagination";
 export { SwirlPopoverAnimation } from "./components/swirl-popover/swirl-popover";
 export { ComputePositionReturn, Placement, Strategy } from "@floating-ui/dom";
+export { SwirlPopover } from "./components/swirl-popover/swirl-popover";
 export { SwirlProgressIndicatorSize, SwirlProgressIndicatorVariant } from "./components/swirl-progress-indicator/swirl-progress-indicator";
 export { SwirlRadioState, SwirlRadioVariant } from "./components/swirl-radio/swirl-radio";
 export { SwirlBoxPadding as SwirlBoxPadding1, SwirlResourceListSemantics } from "./components/swirl-resource-list/swirl-resource-list";
@@ -3339,7 +3341,7 @@ export namespace Components {
           * @default true
          */
         "setAriaAttributes"?: boolean;
-        "swirlPopover": string | HTMLSwirlPopoverElement;
+        "swirlPopover": string | HTMLSwirlPopoverElement | SwirlPopover;
         /**
           * @default true
          */
@@ -11348,7 +11350,7 @@ declare namespace LocalJSX {
           * @default true
          */
         "setAriaAttributes"?: boolean;
-        "swirlPopover": string | HTMLSwirlPopoverElement;
+        "swirlPopover": string | HTMLSwirlPopoverElement | SwirlPopover;
         /**
           * @default true
          */

--- a/packages/swirl-components/src/components/swirl-popover-trigger/swirl-popover-trigger.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-popover-trigger/swirl-popover-trigger.spec.tsx
@@ -14,6 +14,7 @@ describe("swirl-popover-trigger", () => {
     const page = await newSpecPage({
       components: [SwirlPopoverTrigger, SwirlButton],
       html: `
+        <swirl-popover id="popover"></swirl-popover>
         <swirl-popover-trigger swirl-popover="popover">
           <swirl-button label="trigger"></swirl-button>
         </swirl-popover-trigger>

--- a/packages/swirl-components/src/components/swirl-popover-trigger/swirl-popover-trigger.tsx
+++ b/packages/swirl-components/src/components/swirl-popover-trigger/swirl-popover-trigger.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, h, Host, Prop, Watch } from "@stencil/core";
+import { SwirlPopover } from "../swirl-popover/swirl-popover";
 
 @Component({
   shadow: false,
@@ -12,7 +13,7 @@ export class SwirlPopoverTrigger {
   @Prop() hidePopoverWhenInvisible?: boolean = true;
   @Prop() parentScrollContainer?: HTMLElement;
   @Prop() setAriaAttributes?: boolean = true;
-  @Prop() swirlPopover!: string | HTMLSwirlPopoverElement;
+  @Prop() swirlPopover!: string | HTMLSwirlPopoverElement | SwirlPopover;
   @Prop() triggerOnClick?: boolean = true;
   @Prop() triggerOnHover?: boolean = false;
   @Prop() hoverLingerDuration?: number;
@@ -49,6 +50,7 @@ export class SwirlPopoverTrigger {
   disconnectedCallback() {
     this.intersectionObserver?.disconnect();
     const popoverEl = this.getPopoverEl();
+
     if (Boolean(popoverEl)) {
       popoverEl.removeEventListener("mouseenter", this.popoverMouseEnter);
       popoverEl.removeEventListener("mouseleave", this.popoverMouseLeave);
@@ -66,10 +68,11 @@ export class SwirlPopoverTrigger {
     clearTimeout(this.hoverLingerReference);
   }
 
-  private getPopoverEl() {
+  private getPopoverEl(): HTMLSwirlPopoverElement | undefined {
     return typeof this.swirlPopover === "string"
       ? document.querySelector<HTMLSwirlPopoverElement>(`#${this.swirlPopover}`)
-      : this.swirlPopover;
+      : (this.swirlPopover as SwirlPopover)?.el ??
+          (this.swirlPopover as HTMLSwirlPopoverElement);
   }
 
   private getTriggerEl() {
@@ -206,10 +209,7 @@ export class SwirlPopoverTrigger {
       return;
     }
 
-    const popoverId =
-      typeof this.swirlPopover === "string"
-        ? this.swirlPopover
-        : this.swirlPopover?.id;
+    const popoverId = this.getPopoverEl()?.id;
 
     if (triggerEl.tagName.startsWith("SWIRL-")) {
       triggerEl.setAttribute("swirl-aria-controls", popoverId);

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.tsx
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.tsx
@@ -38,7 +38,7 @@ export type SwirlPopoverAnimation = "fade-in" | "scale-in-xy" | "scale-in-y";
   tag: "swirl-popover",
 })
 export class SwirlPopover {
-  @Element() el: HTMLElement;
+  @Element() el: HTMLSwirlPopoverElement;
 
   @Prop() animation?: SwirlPopoverAnimation = "scale-in-xy";
   @Prop() disableScrollLock?: boolean;


### PR DESCRIPTION
In Angular it is easier to pass the SwirlPopover component instance to the swirl-popover-trigger. With these changes instead of this …

```
<swirl-popover #popover></swirl-popover>
<swirl-popover-trigger [swirlPopover]="$any(popover).el"></swirl-popover-trigger>
```

… we can do this …

```
<swirl-popover #popover></swirl-popover>
<swirl-popover-trigger [swirlPopover]="popover"></swirl-popover-trigger>
```

And not get errors like `popoverEl.addEventListener is not a function`.