### PR TITLE
Add custom empty state slot for SwirlTable

### DIFF
--- a/.changeset/kind-shirts-film.md
+++ b/.changeset/kind-shirts-film.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix detection of empty swirl-tables

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -4152,6 +4152,9 @@ export namespace Components {
           * @default "No results found."
          */
         "emptyStateLabel"?: string;
+        /**
+          * @default true
+         */
         "enableDragDrop"?: boolean;
         "label": string;
         /**
@@ -12175,6 +12178,9 @@ declare namespace LocalJSX {
           * @default "No results found."
          */
         "emptyStateLabel"?: string;
+        /**
+          * @default true
+         */
         "enableDragDrop"?: boolean;
         "label": string;
         "onDropRow"?: (event: SwirlTableCustomEvent<SwirlTableDropRowEvent>) => void;

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.spec.tsx
@@ -8,6 +8,12 @@ import { SwirlTable } from "./swirl-table";
   observe() {}
 };
 
+(global as any).MutationObserver = class {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+};
+
 describe("swirl-table", () => {
   it("renders its columns and rows", async () => {
     const page = await newSpecPage({


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-2138/add-fancy-table-empty-state)
- [Design](https://www.figma.com/design/0aF1rkLFUppPDQ68yUZ5Bd/Open-Channels-X-User-Groups?node-id=281-51845&t=Q7rfTBbfZXrwzffq-1)
