### PR TITLE
Fix SwirlTable empty state

### DIFF
--- a/.changeset/shy-berries-stare.md
+++ b/.changeset/shy-berries-stare.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix issue of swirl-table empty state detection

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.tsx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.tsx
@@ -148,6 +148,7 @@ export class SwirlTable {
 
     this.rowMutationObserver.observe(this.bodyEl, {
       childList: true,
+      subtree: true,
     });
   }
 


### PR DESCRIPTION
Empty state wasn't correctly detected when a single container for rows is used. (`<div slot="rows">…</div>`)