### PR TITLE
fix(components): fix runtime error of SwirlModal closing

### DIFF
--- a/.changeset/twelve-mugs-promise.md
+++ b/.changeset/twelve-mugs-promise.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Fix runtime error when trying to close a modal that has already been detached
+from DOM

--- a/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
+++ b/packages/swirl-components/src/components/swirl-modal/swirl-modal.tsx
@@ -106,7 +106,7 @@ export class SwirlModal {
   @State() sidebarScrolledDown = false;
   @State() sidebarScrollable = false;
 
-  private focusTrap: focusTrap.FocusTrap;
+  private focusTrap: focusTrap.FocusTrap | undefined;
   private modalEl: HTMLElement;
   private scrollContainer: HTMLElement;
   private sidebarScrollContainer: HTMLElement;
@@ -151,7 +151,7 @@ export class SwirlModal {
     });
 
     setTimeout(() => {
-      this.focusTrap.activate();
+      this.focusTrap?.activate();
       this.handleAutoFocus();
     }, 200);
   }
@@ -175,7 +175,7 @@ export class SwirlModal {
     this.unlockBodyScroll();
 
     setTimeout(() => {
-      this.focusTrap.deactivate();
+      this.focusTrap?.deactivate();
       this.isOpen = false;
       this.modalClose.emit();
       this.closing = false;


### PR DESCRIPTION
Fix runtime error when trying to close a modal that has already been detached from DOM.