### PR TITLE
feat(components): allow nested avatars in SwirlAvatarGroup

### DIFF
--- a/.changeset/clever-experts-compete.md
+++ b/.changeset/clever-experts-compete.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Allow swirl-avatar-group to be used with nested avatars (e.g. nested in a
+tooltip)

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -410,6 +410,7 @@ export namespace Components {
     }
     interface SwirlAvatarGroup {
         "badge"?: string;
+        "label"?: string;
         /**
           * @default "diagonal"
          */
@@ -8616,6 +8617,7 @@ declare namespace LocalJSX {
     }
     interface SwirlAvatarGroup {
         "badge"?: string;
+        "label"?: string;
         /**
           * @default "diagonal"
          */

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.css
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.css
@@ -15,7 +15,7 @@
   grid-template-rows: repeat(9, 1fr);
   grid-template-columns: repeat(9, 1fr);
 
-  & ::slotted(*:first-of-type) {
+  & ::slotted(*:first-child) {
     z-index: 1;
     display: inline-flex;
     border-radius: 50%;
@@ -26,7 +26,7 @@
     grid-row-end: 10;
   }
 
-  & ::slotted(*:nth-of-type(2)) {
+  & ::slotted(*:nth-child(2)) {
     z-index: 0;
     display: inline-flex;
     border-radius: 50%;
@@ -36,7 +36,7 @@
     grid-row-end: 7;
   }
 
-  & ::slotted(*:nth-of-type(n + 3)) {
+  & ::slotted(*:nth-child(n + 3)) {
     display: none;
   }
 
@@ -61,7 +61,7 @@
     box-shadow: 0 0 0 0.125rem var(--swirl-avatar-group-border-color);
   }
 
-  & ::slotted(*:not(:first-of-type)) {
+  & ::slotted(*:not(:first-child)) {
     margin-left: calc(-1 * var(--s-space-4));
   }
 }

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.stories.ts
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.stories.ts
@@ -45,7 +45,9 @@ const TemplateWithHorizontalLayout = (args) => {
 
   element.innerHTML = `
     <swirl-avatar label="Jane Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a" size="3xs"></swirl-avatar>
-    <swirl-avatar label="John Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=b" size="3xs"></swirl-avatar>
+    <swirl-tooltip content="Test">
+      <swirl-avatar label="John Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=b" size="3xs"></swirl-avatar>
+    </swirl-tooltip>
     <swirl-avatar label="John Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=c" size="3xs"></swirl-avatar>
   `;
 

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.tsx
@@ -16,7 +16,7 @@ export class SwirlAvatarGroup {
   @Prop() label?: string;
   @Prop() layout?: SwirlAvatarGroupLayout = "diagonal";
 
-  @State() avatars: HTMLSwirlAvatarElement[] = [];
+  @State() avatars: HTMLElement[] = [];
 
   private badgeEl: HTMLElement;
 
@@ -38,11 +38,9 @@ export class SwirlAvatarGroup {
   }
 
   private onSlotChange = (event: Event) => {
-    this.avatars = (event.target as HTMLSlotElement)
-      .assignedElements()
-      .filter(
-        (el) => el.tagName.toLowerCase() === "swirl-avatar"
-      ) as HTMLSwirlAvatarElement[];
+    this.avatars = (
+      event.target as HTMLSlotElement
+    ).assignedElements() as HTMLElement[];
 
     this.layOutAvatars();
   };
@@ -50,10 +48,12 @@ export class SwirlAvatarGroup {
   private layOutAvatars() {
     if (this.avatars.length <= 2) {
       this.avatars.forEach((avatar) => {
+        avatar.style.position = "";
         avatar.style.zIndex = "";
       });
     } else {
       this.avatars.forEach((avatar, index) => {
+        avatar.style.position = "relative";
         avatar.style.zIndex = String(this.avatars.length - index);
       });
     }

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -681,6 +681,10 @@
           "description": ""
         },
         {
+          "name": "label",
+          "description": ""
+        },
+        {
           "name": "layout",
           "description": "",
           "values": [


### PR DESCRIPTION
The avatar group wasn't working correctly when the avatars were nested. E.g. in a tooltip.