### PR TITLE
feat(components): add showHeading prop to SwirlAppBar

### DIFF
--- a/.changeset/tame-rats-clean.md
+++ b/.changeset/tame-rats-clean.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Add "show-heading" prop to swirl-app-bar

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -261,6 +261,10 @@ export namespace Components {
         "paddingInlineStart"?: SwirlAppBarPadding;
         "showBackButton"?: boolean;
         "showCloseButton"?: boolean;
+        /**
+          * @default true
+         */
+        "showHeading"?: boolean;
         "showStepperControls"?: boolean;
         /**
           * @default "Next item"
@@ -8485,6 +8489,10 @@ declare namespace LocalJSX {
         "paddingInlineStart"?: SwirlAppBarPadding;
         "showBackButton"?: boolean;
         "showCloseButton"?: boolean;
+        /**
+          * @default true
+         */
+        "showHeading"?: boolean;
         "showStepperControls"?: boolean;
         /**
           * @default "Next item"

--- a/packages/swirl-components/src/components/swirl-app-bar/swirl-app-bar.tsx
+++ b/packages/swirl-components/src/components/swirl-app-bar/swirl-app-bar.tsx
@@ -44,6 +44,7 @@ export class SwirlAppBar {
   @Prop() stepDownButtonLabel?: string = "Next item";
   @Prop() showBackButton?: boolean;
   @Prop() showCloseButton?: boolean;
+  @Prop() showHeading?: boolean = true;
   @Prop() showStepperControls?: boolean;
 
   @State() hasCta: boolean;
@@ -103,7 +104,7 @@ export class SwirlAppBar {
     const className = classnames("app-bar", {
       "app-bar--has-cta": this.hasCta,
       "app-bar--has-right-controls": hasRightControls,
-      "app-bar--has-heading": hasHeading,
+      "app-bar--has-heading": hasHeading && this.showHeading,
     });
 
     const styles = {

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -307,6 +307,10 @@
           "description": ""
         },
         {
+          "name": "show-heading",
+          "description": ""
+        },
+        {
           "name": "show-stepper-controls",
           "description": ""
         },


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-2355/remove-content-planner-label-when-viewport-is-too-small)