### PR TITLE
Use :focus-visible instead of :focus for swirl-resource-list-item styles

### DIFF
--- a/.changeset/gentle-coins-appear.md
+++ b/.changeset/gentle-coins-appear.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Use focus-visible instead of focus for swirl resource list items

--- a/.changeset/gentle-coins-appear.md
+++ b/.changeset/gentle-coins-appear.md
@@ -1,7 +1,0 @@
----
-"@getflip/swirl-components": patch
-"@getflip/swirl-components-angular": patch
-"@getflip/swirl-components-react": patch
----
-
-Use focus-visible instead of focus for swirl resource list items

--- a/.changeset/spotty-trainers-sniff.md
+++ b/.changeset/spotty-trainers-sniff.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+"@getflip/swirl-icons": minor
+---
+
+Use focus-visible instead of focus for swirl resource list items

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.css
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.css
@@ -63,7 +63,7 @@
   }
 
   &:hover:not(.resource-list-item--disabled),
-  &:focus:not(.resource-list-item--disabled) {
+  &:focus-visible:not(.resource-list-item--disabled) {
     background-color: var(--swirl-resource-list-item-background-hovered);
 
     & .resource-list-item__media,


### PR DESCRIPTION
When the browser gives focus back to the item, there was a gray background color visible, we can avoid this by using the :focus-visible to control when the focus is visible