### PR TITLE
fix(components): add proper text color for file chip name

### DIFF
--- a/.changeset/weak-flowers-own.md
+++ b/.changeset/weak-flowers-own.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix swirl-file-chip name color

--- a/packages/swirl-components/src/components/swirl-file-chip/swirl-file-chip.css
+++ b/packages/swirl-components/src/components/swirl-file-chip/swirl-file-chip.css
@@ -18,7 +18,6 @@
   gap: var(--s-space-12);
 }
 
-
 .file-chip:hover,
 .file-chip:focus-within {
   &.file-chip--one-action .file-chip__info > * {
@@ -52,6 +51,7 @@
 }
 
 .file-chip__name {
+  color: var(--s-text-default);
   font-weight: var(--s-font-weight-semibold);
 }
 


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-3706/adjust-file-chip-component)