### PR TITLE
Tweak SwirlCarousel stepper button styles

### DIFF
--- a/.changeset/forty-snakes-divide.md
+++ b/.changeset/forty-snakes-divide.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Tweak swirl-carousel stepper button styles

--- a/packages/swirl-components/src/components/swirl-carousel/swirl-carousel.tsx
+++ b/packages/swirl-components/src/components/swirl-carousel/swirl-carousel.tsx
@@ -275,7 +275,7 @@ export class SwirlCarousel {
               label={this.previousSlideButtonLabel}
               onClick={this.onPreviousSlideButtonClick}
               pill
-              variant="floating"
+              variant="translucent"
             ></swirl-button>
           )}
           {this.isScrollable && !this.isAtEnd && (
@@ -286,7 +286,7 @@ export class SwirlCarousel {
               label={this.nextSlideButtonLabel}
               onClick={this.onNextSlideButtonClick}
               pill
-              variant="floating"
+              variant="translucent"
             ></swirl-button>
           )}
           <div


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-3771/hover-state-of-carousel-arrow-buttons-looks-broken)
