### PR TITLE
Fix swirl-button outline/default intent color tokens

### DIFF
--- a/.changeset/fix-button-outline-default-colors.md
+++ b/.changeset/fix-button-outline-default-colors.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix swirl-button outline/default intent color tokens: use `--s-text-subdued` for text and `--s-icon-default` for icon instead of `--s-text-default` and `--s-icon-strong`.

--- a/packages/swirl-components/src/components/swirl-button/swirl-button.css
+++ b/packages/swirl-components/src/components/swirl-button/swirl-button.css
@@ -192,7 +192,7 @@
 }
 
 .button--variant-outline {
-  color: var(--s-text-default);
+  color: var(--s-text-subdued);
   outline: var(--s-border-width-default) solid var(--s-border-strong);
   outline-offset: calc(var(--s-border-width-default) * -1);
 
@@ -229,7 +229,7 @@
   }
 
   & .button__icon {
-    color: var(--s-icon-strong);
+    color: var(--s-icon-default);
   }
 }
 


### PR DESCRIPTION
Variant: outline
Intent: default
Please change the color token of the text to --s-text-subdued
Change also the color of the icon into --s-icon-default