### PR TITLE
docs: Add MCP Server usage documentation

### DIFF
--- a/packages/swirl-components/src/docs/00-introduction.stories.mdx
+++ b/packages/swirl-components/src/docs/00-introduction.stories.mdx
@@ -20,6 +20,8 @@ System.
 
 - Check the ["Usage"](/?path=/story/usage-get-started--get-started) section for
   information on how to use the component library in your projects.
+- Check the ["MCP Server"](/?path=/story/usage-mcp-server--mcp-server) section
+  to let AI agents (Claude Code, Cursor, etc.) use Swirl components.
 - Check the
   ["Contributions"](/?path=/story/contributions-get-started--get-started)
   section for information on how to contribute to the component library.

--- a/packages/swirl-components/src/docs/01-usage/02-mcp-server.stories.mdx
+++ b/packages/swirl-components/src/docs/01-usage/02-mcp-server.stories.mdx
@@ -56,7 +56,6 @@ resources and avoids the `npx` cold-start.
 | **list_components**       | Lists all Swirl UI components with brief summaries and related components.   |
 | **list_icons**            | Lists all Swirl icon components.                                             |
 | **list_symbols**          | Lists all Swirl symbol components.                                           |
-| **list_emojis**           | Lists all Swirl emoji components.                                            |
 | **get_component_details** | Full component docs: props, events, slots, examples, and accessibility info. |
 | **get_started**           | Installation and setup guide for Web Components, Angular, and React.         |
 

--- a/packages/swirl-components/src/docs/01-usage/02-mcp-server.stories.mdx
+++ b/packages/swirl-components/src/docs/01-usage/02-mcp-server.stories.mdx
@@ -1,0 +1,72 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+<Meta title="Usage/MCP Server" />
+
+# 🤖 MCP Server
+
+The [`@getflip/swirl-mcp`](https://www.npmjs.com/package/@getflip/swirl-mcp)
+package is a [Model Context Protocol](https://modelcontextprotocol.io) server
+that lets AI coding assistants — such as Claude Code, Cursor, and Claude
+Desktop — discover and use Swirl components correctly. Once configured, the
+agent can list available components, fetch their props, events, slots, and
+accessibility notes, and read installation instructions on demand, so the code
+it writes for you matches the design system.
+
+## Setup
+
+The MCP server is added through your AI client's MCP configuration. Both
+options below result in the same set of tools — pick whichever fits your
+workflow.
+
+### Local (stdio)
+
+Each client spawns its own copy of the server locally via `npx`. No network
+dependency, always on the latest published version.
+
+```json
+{
+  "mcpServers": {
+    "swirl": {
+      "command": "npx",
+      "args": ["-y", "@getflip/swirl-mcp"]
+    }
+  }
+}
+```
+
+### Remote (HTTP)
+
+Use the always-on instance hosted by us. Lighter on local
+resources and avoids the `npx` cold-start.
+
+```json
+{
+  "mcpServers": {
+    "swirl": {
+      "url": "https://swirl-mcp.engage.team.getflip.gg/mcp"
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool                      | Description                                                                  |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| **list_components**       | Lists all Swirl UI components with brief summaries and related components.   |
+| **list_icons**            | Lists all Swirl icon components.                                             |
+| **list_symbols**          | Lists all Swirl symbol components.                                           |
+| **list_emojis**           | Lists all Swirl emoji components.                                            |
+| **get_component_details** | Full component docs: props, events, slots, examples, and accessibility info. |
+| **get_started**           | Installation and setup guide for Web Components, Angular, and React.         |
+
+All tools accept a `version` parameter that should match the
+`@getflip/swirl-components` version installed in your project, so the agent
+reads documentation that matches the code it's editing.
+
+## Where to next?
+
+For local testing with the
+[MCP Inspector](https://github.com/modelcontextprotocol/inspector) and other
+contributor-facing details, see the
+[package README](https://github.com/getflip/swirl/tree/main/packages/swirl-mcp).

--- a/packages/swirl-mcp/README.md
+++ b/packages/swirl-mcp/README.md
@@ -55,7 +55,6 @@ npx @modelcontextprotocol/inspector
 | **list_components**       | Lists all Swirl UI components with brief summaries and related components.   |
 | **list_icons**            | Lists all Swirl icon components.                                             |
 | **list_symbols**          | Lists all Swirl symbol components.                                           |
-| **list_emojis**           | Lists all Swirl emoji components.                                            |
 | **get_component_details** | Full component docs: props, events, slots, examples, and accessibility info. |
 | **get_started**           | Installation and setup guide for Web Components, Angular, and React.         |
 

--- a/packages/swirl-mcp/src/artifact-library.ts
+++ b/packages/swirl-mcp/src/artifact-library.ts
@@ -55,8 +55,5 @@ function categorize(tag: string): ComponentCategory {
   if (tag.startsWith("swirl-symbol-")) {
     return "symbol";
   }
-  if (tag.startsWith("swirl-emoji-")) {
-    return "emoji";
-  }
   return "core";
 }

--- a/packages/swirl-mcp/src/create-server.ts
+++ b/packages/swirl-mcp/src/create-server.ts
@@ -6,7 +6,6 @@ import {
   registerListComponents,
   registerListIcons,
   registerListSymbols,
-  registerListEmojis,
 } from "./tools/list-components.js";
 import { registerGetComponentDetails } from "./tools/get-component-details.js";
 import { registerGetStarted } from "./tools/get-started.js";
@@ -46,7 +45,6 @@ export function createMcpServer(): McpServer {
   registerListComponents(server, loadLibrary);
   registerListIcons(server, loadLibrary);
   registerListSymbols(server, loadLibrary);
-  registerListEmojis(server, loadLibrary);
   registerGetComponentDetails(server, loadLibrary);
   registerGetStarted(server, loadLibrary);
 

--- a/packages/swirl-mcp/src/tools/list-components.ts
+++ b/packages/swirl-mcp/src/tools/list-components.ts
@@ -18,7 +18,7 @@ export function registerListComponents(
     loadLibrary,
     "list_components",
     "List all Swirl design system UI components (buttons, modals, forms, etc.) with brief summaries and related components. " +
-      "Does NOT include icons, symbols, or emojis — use list_icons, list_symbols, or list_emojis for those. " +
+      "Does NOT include icons or symbols — use list_icons or list_symbols for those. " +
       "Use get_component_details for full props, events, slots, and examples. " +
       "IMPORTANT: First read the user's package.json to determine their installed @getflip/swirl-components version, then pass it as the 'version' parameter.",
     "core"
@@ -49,21 +49,6 @@ export function registerListSymbols(
       "Use get_component_details for full details on a specific symbol. " +
       "IMPORTANT: First read the user's package.json to determine their installed @getflip/swirl-components version, then pass it as the 'version' parameter.",
     "symbol"
-  );
-}
-
-export function registerListEmojis(
-  server: McpServer,
-  loadLibrary: LoadLibrary
-) {
-  registerListTool(
-    server,
-    loadLibrary,
-    "list_emojis",
-    "List all Swirl emoji components (swirl-emoji-*). " +
-      "Use get_component_details for full details on a specific emoji. " +
-      "IMPORTANT: First read the user's package.json to determine their installed @getflip/swirl-components version, then pass it as the 'version' parameter.",
-    "emoji"
   );
 }
 

--- a/packages/swirl-mcp/src/types.ts
+++ b/packages/swirl-mcp/src/types.ts
@@ -13,4 +13,4 @@ export interface ComponentIndexEntry {
   relatedComponents?: string[];
 }
 
-export type ComponentCategory = "core" | "icon" | "symbol" | "emoji";
+export type ComponentCategory = "core" | "icon" | "symbol";


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-3895/create-documentation-for-swirl-aimcp)