### PR TITLE
Fix swirl-image-grid-item reconnect

### DIFF
--- a/.changeset/flat-lies-appear.md
+++ b/.changeset/flat-lies-appear.md
@@ -1,0 +1,6 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Ensure image is rendered after item is reconnected to the DOM in
+swirl-image-grid-item

--- a/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
+++ b/packages/swirl-components/src/components/swirl-image-grid-item/swirl-image-grid-item.tsx
@@ -85,10 +85,6 @@ export class SwirlImageGridItem {
 
   componentDidLoad() {
     this.setupIntersectionObserver();
-
-    if (this.img?.complete) {
-      this.loaded = true;
-    }
   }
 
   componentDidRender() {
@@ -99,17 +95,18 @@ export class SwirlImageGridItem {
 
   connectedCallback() {
     this.computedSrc = this.src;
+    this.setupIntersectionObserver();
   }
 
   disconnectedCallback() {
     this.intersectionObserver?.disconnect();
-    this.computedSrc = "";
+    this.intersectionObserver = undefined;
     this.img?.removeEventListener("load", this.onLoad);
     this.img?.removeEventListener("error", this.onError);
   }
 
   private setupIntersectionObserver() {
-    if (this.loading !== "intersecting") {
+    if (this.loading !== "intersecting" || this.intersectionObserver) {
       return;
     }
 


### PR DESCRIPTION
Fix `swirl-image-grid-item` showing the skeleton permanently after a drag-and-drop reorder moves an off-screen item into view. 
The `IntersectionObserver` was only set up in `componentDidLoad` and never recreated on reattach, so `inViewport` stayed `false` and the `<img>` never rendered — now it's also (re)initialized in `connectedCallback`, with a guard to avoid double-setup. 