### PR TITLE
Allow autoGrow input to shrink in swirl-text-input

### DIFF
--- a/.changeset/friendly-suns-wait.md
+++ b/.changeset/friendly-suns-wait.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Allow autoGrow input to shrink in swirl-text-input

--- a/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.tsx
+++ b/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.tsx
@@ -140,6 +140,7 @@ export class SwirlTextInput implements SwirlFormInput {
   private adjustInputSize() {
     if (this.rows > 1 || this.autoGrow) {
       this.inputEl.style.width = "";
+      this.inputEl.style.height = "auto";
       this.inputEl.style.height = Boolean(this.inputEl.scrollHeight)
         ? this.inputEl.scrollHeight / 16 + "rem"
         : "";


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-3863/post-create-title-section-does-not-collapse)
