### PR TITLE
Make blur tokens Flutter-compatible for BackdropFilter

### DIFF
--- a/.changeset/flutter-blur-tokens.md
+++ b/.changeset/flutter-blur-tokens.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-tokens": patch
+---
+
+Make blur tokens Flutter-compatible. Dimension-typed tokens (`blur-s`, `blur-m`, `blur-l`) are now emitted as numeric `double` values in the generated Dart files instead of CSS px strings, so they can be passed directly to `ImageFilter.blur` / `BackdropFilter`.

--- a/packages/swirl-tokens/config.dark.json
+++ b/packages/swirl-tokens/config.dark.json
@@ -31,6 +31,7 @@
         "color/hex8flutter",
         "shadow-attribute/flutter",
         "shadow/flutter",
+        "blur/flutter",
         "content/flutter/literal",
         "asset/flutter/literal",
         "font/flutter/literal",

--- a/packages/swirl-tokens/config.light.json
+++ b/packages/swirl-tokens/config.light.json
@@ -31,6 +31,7 @@
         "color/hex8flutter",
         "shadow-attribute/flutter",
         "shadow/flutter",
+        "blur/flutter",
         "content/flutter/literal",
         "asset/flutter/literal",
         "font/flutter/literal",

--- a/packages/swirl-tokens/dart/lib/styles.dark.dart
+++ b/packages/swirl-tokens/dart/lib/styles.dark.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Tue, 05 May 2026 14:04:20 GMT
+// Generated on Thu, 07 May 2026 06:27:53 GMT
 
 
 
@@ -29,9 +29,9 @@ class SwirlDesignTokensDark {
     static const backgroundDefault = Color(0xFF191919); /* Usually used for the page background and elements that should not elevate from the background. */
     static const backgroundHovered = Color(0xFF232323); /* Used if a component with “Background/Default” has a hovered state. */
     static const backgroundPressed = Color(0xFF2B2B2B); /* Used if a component with “Background/Default” has a pressed state. */
-    static const blurL = "16px";
-    static const blurM = "8px";
-    static const blurS = "4px";
+    static const blurL = 16.00;
+    static const blurM = 8.00;
+    static const blurS = 4.00;
     static const borderCritical = Color(0xFFE46464); /* Usally used as an border on critical components. */
     static const borderDefault = Color(0x1FFFFFFF); /* Usually used for low emphasis borders and espacially divider elements. */
     static const borderHighlight = Color(0xFF6DA8FB); /* Used as border color on containers that need to be highlighted (e.g. form fields). */

--- a/packages/swirl-tokens/dart/lib/styles.light.dart
+++ b/packages/swirl-tokens/dart/lib/styles.light.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Tue, 05 May 2026 14:04:20 GMT
+// Generated on Thu, 07 May 2026 06:27:53 GMT
 
 
 
@@ -29,9 +29,9 @@ class SwirlDesignTokensLight {
     static const backgroundDefault = Color(0xFFFFFFFF); /* Usually used for the page background and elements that should not elevate from the background. */
     static const backgroundHovered = Color(0xFFF2F2F2); /* Used if a component with “Background/Default” has a hovered state. */
     static const backgroundPressed = Color(0xFFEAEAEA); /* Used if a component with “Background/Default” has a pressed state. */
-    static const blurL = "16px";
-    static const blurM = "8px";
-    static const blurS = "4px";
+    static const blurL = 16.00;
+    static const blurM = 8.00;
+    static const blurS = 4.00;
     static const borderCritical = Color(0xFFD50636); /* Usally used as an border on critical components. */
     static const borderDefault = Color(0x1F000000); /* Usually used for low emphasis borders and espacially divider elements. */
     static const borderHighlight = Color(0xFF0037AF); /* Used as border color on containers that need to be highlighted (e.g. form fields). */

--- a/packages/swirl-tokens/scripts/build.ts
+++ b/packages/swirl-tokens/scripts/build.ts
@@ -119,6 +119,8 @@ StyleDictionary.registerTransform({
       category = "size";
     } else if (token.type === "color") {
       category = "color";
+    } else if (token.type === "dimension") {
+      category = "dimension";
     }
 
     const generatedAttrs = {
@@ -176,6 +178,16 @@ StyleDictionary.registerTransform({
         )}), offset: Offset(${x}, ${y}), blurRadius: ${blur})`;
       })
       .join(", ")}]`;
+  },
+});
+
+StyleDictionary.registerTransform({
+  name: "blur/flutter",
+  type: "value",
+  transitive: true,
+  matcher: (token) => token.type === "dimension",
+  transformer: function (token) {
+    return parseFloat(String(token.value).replace("px", "")).toFixed(2);
   },
 });
 


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/EMPMOB-1922/make-blur-tokens-flutter-compatible-for-backdropfilter)

For reference: https://github.com/getflip/swirl/commit/238d1a896fb16171539224580abe5abe3a7b9cb6
