### PR TITLE
Introduce graceful failure for not supported swirl versions in token tools

### DIFF
--- a/.changeset/gold-starfishes-notice.md
+++ b/.changeset/gold-starfishes-notice.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-mcp": patch
+---
+
+Introduce graceful failure for not supported swirl versions in token tools

--- a/packages/swirl-mcp/src/artifact-library.ts
+++ b/packages/swirl-mcp/src/artifact-library.ts
@@ -11,12 +11,12 @@ import type {
 export class ArtifactLibrary {
   private readonly catalog: ComponentIndexEntry[];
   private readonly tagIndex: Map<string, ComponentIndexEntry>;
-  private readonly tokens: AgentTokensIndex;
+  private readonly tokens: AgentTokensIndex | undefined;
   private readonly dataSource: DataSource;
 
   private constructor(
     catalog: ComponentIndexEntry[],
-    tokens: AgentTokensIndex,
+    tokens: AgentTokensIndex | undefined,
     dataSource: DataSource
   ) {
     this.catalog = catalog;
@@ -67,17 +67,23 @@ export class ArtifactLibrary {
     return this.dataSource.readText(`${name}.md`);
   }
 
-  getTokensByCategory(category: TokenCategory): TokenEntry[] {
-    return this.tokens[category];
+  getTokensByCategory(category: TokenCategory): TokenEntry[] | undefined {
+    return this.tokens?.[category];
   }
 
   private static async fromDataSource(
     dataSource: DataSource
   ): Promise<ArtifactLibrary> {
-    const [components, tokens] = await Promise.all([
-      dataSource.readJson<AgentComponentsIndex>("components-index.json"),
-      dataSource.readJson<AgentTokensIndex>("tokens.json"),
-    ]);
+    const components = await dataSource.readJson<AgentComponentsIndex>(
+      "components-index.json"
+    );
+
+    let tokens: AgentTokensIndex | undefined;
+    try {
+      tokens = await dataSource.readJson<AgentTokensIndex>("tokens.json");
+    } catch {
+      tokens = undefined;
+    }
 
     return new ArtifactLibrary(components.components, tokens, dataSource);
   }

--- a/packages/swirl-mcp/src/tools/list-tokens.ts
+++ b/packages/swirl-mcp/src/tools/list-tokens.ts
@@ -85,6 +85,18 @@ function registerListTokensTool(
     async ({ version, format }: { version: string; format: TokenFormat }) => {
       const lib = await loadLibrary(version);
       const tokens = lib.getTokensByCategory(category);
+
+      if (tokens === undefined) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `The "${name}" tool is not supported for the @getflip/swirl-components@${version} version`,
+            },
+          ],
+        };
+      }
       const formatted = tokens
         .map((t) => formatToken(t, format))
         .filter((t): t is FormattedToken => t !== null);


### PR DESCRIPTION
## Summary
Adding the token tools in #1668 made `tokens.json` a hard dependency of `ArtifactLibrary.fromDataSource`. Older `@getflip/swirl-ai` versions don't ship that file, so every MCP tool — not just the token ones — failed for users on older `@getflip/swirl-components` versions.
