### PR TITLE
Add size and actionsOrientation props to SwirlDialog

### DIFF
--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -27,7 +27,7 @@ import { SwirlChipBorderRadius, SwirlChipIconColor, SwirlChipIntent, SwirlChipSi
 import { SwirlColumnsSpacing } from "./components/swirl-columns/swirl-columns";
 import { SwirlDataCellIntent } from "./components/swirl-data-cell/swirl-data-cell";
 import { WCDatepickerLabels } from "wc-datepicker/dist/types/components/wc-datepicker/wc-datepicker";
-import { SwirlDialogIntent } from "./components/swirl-dialog/swirl-dialog";
+import { SwirlDialogIntent, SwirlDialogSize } from "./components/swirl-dialog/swirl-dialog";
 import { SwirlCursor, SwirlDialogToggleEvent } from "./utils";
 import { SwirlEmojiSize } from "./components/swirl-emoji/swirl-emoji.types";
 import { SwirlButtonVariant as SwirlButtonVariant1 } from "./components/swirl-button/swirl-button";
@@ -109,7 +109,7 @@ export { SwirlChipBorderRadius, SwirlChipIconColor, SwirlChipIntent, SwirlChipSi
 export { SwirlColumnsSpacing } from "./components/swirl-columns/swirl-columns";
 export { SwirlDataCellIntent } from "./components/swirl-data-cell/swirl-data-cell";
 export { WCDatepickerLabels } from "wc-datepicker/dist/types/components/wc-datepicker/wc-datepicker";
-export { SwirlDialogIntent } from "./components/swirl-dialog/swirl-dialog";
+export { SwirlDialogIntent, SwirlDialogSize } from "./components/swirl-dialog/swirl-dialog";
 export { SwirlCursor, SwirlDialogToggleEvent } from "./utils";
 export { SwirlEmojiSize } from "./components/swirl-emoji/swirl-emoji.types";
 export { SwirlButtonVariant as SwirlButtonVariant1 } from "./components/swirl-button/swirl-button";
@@ -968,6 +968,10 @@ export namespace Components {
         "primaryActionLabel"?: string;
         "returnFocusTo"?: HTMLElement | string;
         "secondaryActionLabel"?: string;
+        /**
+          * @default "default"
+         */
+        "size"?: SwirlDialogSize;
     }
     interface SwirlEmoji {
         /**
@@ -10857,6 +10861,10 @@ declare namespace LocalJSX {
         "primaryActionLabel"?: string;
         "returnFocusTo"?: HTMLElement | string;
         "secondaryActionLabel"?: string;
+        /**
+          * @default "default"
+         */
+        "size"?: SwirlDialogSize;
     }
     interface SwirlEmoji {
         /**
@@ -15781,6 +15789,7 @@ declare namespace LocalJSX {
         "hideLabel": boolean;
         "intent": SwirlDialogIntent;
         "label": string;
+        "size": SwirlDialogSize;
         "primaryActionLabel": string;
         "returnFocusTo": HTMLElement | string;
         "secondaryActionLabel": string;

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
@@ -92,6 +92,12 @@
   }
 }
 
+.dialog--large .dialog__body {
+  @media (--from-desktop-without-touch) {
+    width: 35rem; /* 560px */
+  }
+}
+
 .dialog__heading {
   margin: 0;
   margin-bottom: var(--s-space-8);
@@ -145,31 +151,16 @@
 }
 
 .dialog__actions {
-  display: grid;
-  gap: var(--s-space-8);
-  width: fit-content;
   min-width: 0;
   max-width: 100%;
-}
-
-.dialog__actions:has(> :only-child) {
-  width: 100%;
-  grid-template-columns: minmax(0, 1fr);
-  justify-items: end;
-}
-
-.dialog__actions:has(> :only-child) > swirl-button {
-  min-width: 0;
-  max-width: 100%;
-}
-
-.dialog__actions:has(> :nth-child(2)) {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  width: 100%;
 
   @media (--from-desktop) {
     width: auto;
   }
+}
+
+.dialog__actions--vertical {
+  width: 100%;
 }
 
 .dialog__left_controls {

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
@@ -153,6 +153,7 @@
 .dialog__actions {
   min-width: 0;
   max-width: 100%;
+  width: 100%;
 
   @media (--from-desktop) {
     width: auto;
@@ -161,6 +162,19 @@
 
 .dialog__actions--vertical {
   width: 100%;
+}
+
+/* Horizontal: buttons share equal width on mobile, constrained to prevent overflow */
+.dialog__actions:not(.dialog__actions--vertical) > swirl-button {
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+
+  @media (--from-desktop) {
+    flex: initial;
+    min-width: 0;
+    max-width: 100%;
+  }
 }
 
 .dialog__left_controls {

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.stories.ts
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.stories.ts
@@ -3,10 +3,18 @@ import Docs from "./swirl-dialog.mdx";
 
 export default {
   argTypes: {
+    actionsOrientation: {
+      control: "radio",
+      options: ["horizontal", "vertical"],
+    },
     returnFocusTo: {
       control: "text",
       description:
         "Use when dialog trigger element is unmounted before the dialog is closed.",
+    },
+    size: {
+      control: "radio",
+      options: ["default", "large"],
     },
   },
   component: "swirl-dialog",
@@ -52,8 +60,10 @@ const Template = (args) => {
 export const SwirlDialog = Template.bind({});
 
 SwirlDialog.args = {
+  actionsOrientation: "horizontal",
   intent: "primary",
   label: "Dialog",
   primaryActionLabel: "Leave",
   secondaryActionLabel: "Cancel",
+  size: "default",
 };

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.tsx
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.tsx
@@ -12,8 +12,10 @@ import {
 import classnames from "classnames";
 import { tabbable } from "tabbable";
 import { SwirlDialogToggleEvent } from "../../utils";
+import { SwirlButtonGroupOrientation } from "../swirl-button-group/swirl-button-group";
 
 export type SwirlDialogIntent = "primary" | "critical";
+export type SwirlDialogSize = "default" | "large";
 
 /**
  * @slot slot - The dialog content
@@ -27,9 +29,11 @@ export type SwirlDialogIntent = "primary" | "critical";
 export class SwirlDialog {
   @Element() el: HTMLElement;
 
+  @Prop() actionsOrientation?: SwirlButtonGroupOrientation = "horizontal";
   @Prop() hideLabel?: boolean;
   @Prop() intent?: SwirlDialogIntent = "primary";
   @Prop() label!: string;
+  @Prop() size?: SwirlDialogSize = "default";
   @Prop() primaryActionLabel?: string;
   @Prop() returnFocusTo?: HTMLElement | string;
   @Prop() secondaryActionLabel?: string;
@@ -175,7 +179,10 @@ export class SwirlDialog {
   }
 
   render() {
-    const className = classnames("dialog", { "dialog--closing": this.closing });
+    const className = classnames("dialog", {
+      "dialog--closing": this.closing,
+      "dialog--large": this.size === "large",
+    });
     const hasLeftControls = Boolean(
       this.el.querySelector('[slot="left-controls"]')
     );
@@ -213,7 +220,14 @@ export class SwirlDialog {
               )}
 
               {(hasSecondaryAction || hasPrimaryAction) && (
-                <div class="dialog__actions">
+                <swirl-button-group
+                  class={classnames("dialog__actions", {
+                    "dialog__actions--vertical":
+                      this.actionsOrientation === "vertical",
+                  })}
+                  orientation={this.actionsOrientation}
+                  stretch={this.actionsOrientation === "vertical"}
+                >
                   {hasSecondaryAction && (
                     <swirl-button
                       label={this.secondaryActionLabel}
@@ -228,7 +242,7 @@ export class SwirlDialog {
                       variant="flat"
                     ></swirl-button>
                   )}
-                </div>
+                </swirl-button-group>
               )}
             </div>
           </div>


### PR DESCRIPTION
- Add `size` prop ("default" | "large") — large sets dialog width to 560px on desktop
- Add `actionsOrientation` prop ("horizontal" | "vertical") — uses SwirlButtonGroup in the footer so buttons can be stacked vertically with full width stretch

<img width="3536" height="2560" alt="image" src="https://github.com/user-attachments/assets/b98478a2-a9e6-4964-a7e2-d9625110e93b" />
