### PR TITLE
Fix size L for translucent swirl-button

### DIFF
--- a/.changeset/violet-readers-sell.md
+++ b/.changeset/violet-readers-sell.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix size in translucent swirl-button

--- a/packages/swirl-components/src/components/swirl-button/swirl-button.css
+++ b/packages/swirl-components/src/components/swirl-button/swirl-button.css
@@ -454,6 +454,14 @@
       color: var(--s-icon-default);
     }
   }
+
+  &.button--size-l {
+    padding: var(--s-space-12) var(--s-space-20);
+
+    &.button--icon-only {
+      padding: var(--s-space-12);
+    }
+  }
 }
 
 .button--icon-position-end {


### PR DESCRIPTION
## Summary
- Adds the missing `&.button--size-l` block to `.button--variant-translucent` in `swirl-button.css`, so `<swirl-button variant="translucent" size="l">` actually grows to L dimensions.
- Before: padding `8px 16px`, height `40px` (same as M, inconsistent with every other variant in an L-size row).
- After: padding `12px 20px`, height `48px` — matches ghost / flat / outline / plain / on-image.

## Test plan
- [x] Stencil build succeeds and the compiled bundle contains `.button--variant-translucent.button--size-l { padding: var(--s-space-12) var(--s-space-20) }`.
- [x] Storybook render (puppeteer + computed styles) confirms translucent L now matches ghost / flat / outline L (padding `12px 20px`, height `48px`).
- [x] Visual check in Storybook against the size-L row for the translucent variant.