### PR TITLE
ACT-3449: Fix swirl-date-input does not clear its mask when value is empty/falsy

### DIFF
--- a/.changeset/early-balloons-check.md
+++ b/.changeset/early-balloons-check.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix swirl-date-input not clearing its mask when value is set to empty/falsy

--- a/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
+++ b/packages/swirl-components/src/components/swirl-date-input/swirl-date-input.tsx
@@ -296,6 +296,8 @@ export class SwirlDateInput {
       } else {
         this.invalidInput.emit(this.value);
       }
+    } else {
+      this.mask.value = "";
     }
   }
 


### PR DESCRIPTION
## Summary

- [ACT-3449](https://linear.app/flip/issue/ACT-3449/swirl-swirl-date-input-does-not-clear-its-mask-when-value-is-set-to)

