### PR TITLE
fix(components): fix pointer events issue with SwirlPopover

### DIFF
--- a/.changeset/good-kings-pump.md
+++ b/.changeset/good-kings-pump.md
@@ -1,0 +1,6 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix swirl-popover pointer events when nested inside swirl-resource-list-item's
+control slot

--- a/packages/swirl-components/src/styles/global.css
+++ b/packages/swirl-components/src/styles/global.css
@@ -126,6 +126,17 @@ dt {
   padding: 0;
 }
 
+/*
+ * Sometimes a swirl-popover is slotted into a swirl-resource-list-item control
+ * slot. The controls pointer events are disabled if the item is not hovered or
+ * focused. This means that the popover will not be clickable if the item is not
+ * hovered or focused. This style ensures that the popover is clickable even if
+ * the item is not hovered or focused.
+*/
+swirl-resource-list-item swirl-popover {
+  pointer-events: auto;
+}
+
 /* Responsive design helper classes to hide elements for specific viewports */
 
 .hide-from-mobile {


### PR DESCRIPTION
## Summary

The issue is caused by popovers being nested inside swirl-resource-list-item controls, which have disabled pointer events when not hovered/focused.

This is more of a workaround. Technically, swirl-popover elements shouldn't be nested inside a swirl-resource-list-item "control" slot, but sometimes our Angular component structure makes it hard to avoid.

- [Ticket](https://linear.app/flip/issue/ENG-4158/chat-popover-actions-dont-work)
