### PR TITLE
fix: update shadow token for nested popovers in SwirlMenu

### DIFF
--- a/packages/swirl-components/src/components/swirl-menu/swirl-menu.css
+++ b/packages/swirl-components/src/components/swirl-menu/swirl-menu.css
@@ -51,7 +51,7 @@
       z-index: 1;
       max-width: 22.5rem;
       border-radius: var(--s-border-radius-base);
-      box-shadow: var(--s-shadow-level-1);
+      box-shadow: var(--s-shadow-level-2);
       padding: var(--s-space-4);
       outline: var(--s-border-width-default) solid var(--s-border-translucent-outline);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the shadow token used for nested/sub-level popovers in the SwirlMenu component.

### Changes
- Updated `box-shadow` from `var(--s-shadow-level-1)` to `var(--s-shadow-level-2)` for non-root menu popovers
- This applies to nested popovers that appear when opening sub-level menu items

### Technical Details
The fix is applied in `swirl-menu.css` within the `:not(.menu--mobile) &:not(.menu--root) & .menu__menu` selector, which specifically targets nested menu popovers in desktop view.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BUI-364](https://linear.app/flip/issue/BUI-364/wrong-shadow-token-on-sub-level-popovers-in-the-swirlmenu-component)

<div><a href="https://cursor.com/agents/bc-b48cf21b-30b4-4cfe-a050-b527aae39866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b48cf21b-30b4-4cfe-a050-b527aae39866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

