### PR TITLE
Add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Swirl is a Yarn 1 (classic) + Turborepo monorepo of design-system packages (`packages/*`)
+plus a Next.js docs site (`apps/swirl-docs`). There is no database/backend service. See
+`README.md` for the package overview and standard commands.
+
+### Environment
+- Node 22 + Yarn 1.22 are the shipped defaults; `node` engines only require `>=14`. CI pins
+  Node 20.x but the build/lint/tests work on Node 22 as well.
+- Dependencies install via `yarn install` (already run by the startup update script).
+- `puppeteer` (used by `swirl-components` Stencil e2e/spec tests) downloads Chromium on first
+  install. That download is cached in `~/.cache/puppeteer` and persists in the VM snapshot, so
+  later `yarn install` runs are fast no-ops. If a fresh install ever hangs on puppeteer's
+  postinstall after Chromium is already cached, kill that one process and re-run with
+  `PUPPETEER_SKIP_DOWNLOAD=true yarn install`.
+
+### Build / lint / test (standard scripts, see `package.json` / `turbo.json`)
+- Build the libraries with `yarn build:packages` (Turbo handles order: tokens & icons → components → react/angular). Avoid root `yarn build`: it also builds `swirl-docs`, whose `prebuild` fetches OpenAPI specs from a private GitLab repo and fails without secrets.
+- `yarn lint` and `yarn test` work out of the box for the library packages.
+
+### Running the product (dev)
+- `yarn dev` (root) is the primary dev experience: it runs the `swirl-components` Stencil watch
+  build + Storybook on http://localhost:6006, plus tokens/icons/bridge watchers. It excludes
+  docs/angular/react. Storybook takes ~30-60s to come up; wait for "Local: http://localhost:6006/".
+- During `yarn dev` startup the `bridge` watcher may briefly print TS2306 errors against
+  `swirl-components` type output; these clear themselves once Stencil finishes generating types.
+
+### Known limitations (need secrets)
+- `apps/swirl-docs` is OPTIONAL and is excluded from the CI lint/test workflow. Its `prebuild`,
+  `next dev` (`yarn dev:docs`), build, and `vitest` tests require `GITLAB_ACCESS_TOKEN`,
+  `GITLAB_FLIP_REPO_ID` (OpenAPI specs) and Algolia keys. Without them, the docs `vitest` run
+  hangs/fails — run `yarn test --filter='!swirl-docs'` to test just the library packages.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the Swirl monorepo so future Cloud Agents can start fast. Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing non-obvious startup/run caveats.

No application code changed.

## Environment verified
- Node 22 + Yarn 1.22 (shipped defaults). Dependencies install via `yarn install`.
- `puppeteer` downloads Chromium on first install; cached in `~/.cache/puppeteer` and persisted in the snapshot, so later installs are fast no-ops.

## Checks run
- `yarn build:packages` — all 9 library packages build (tokens → icons → components → react/angular/etc.)
- `yarn lint` — passes
- `yarn test --filter='!swirl-docs'` — `swirl-components` 494 tests / 104 suites + `bridge` pass
- `yarn dev` — Storybook serves on http://localhost:6006

## Hello-world
Loaded Storybook, opened the `SwirlButton` story, and changed the `label` control to "Hello World"; the rendered button updated live.

[swirl_storybook_button_hello_world.mp4](https://cursor.com/agents/bc-899dea48-9017-4d58-8593-c95a3ad69dd8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fswirl_storybook_button_hello_world.mp4)
[Button rendered with Hello World label](https://cursor.com/agents/bc-899dea48-9017-4d58-8593-c95a3ad69dd8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_button_hello_world.webp)

## Notes
- `apps/swirl-docs` is optional and excluded from CI lint/test; its prebuild/dev/build/tests need `GITLAB_ACCESS_TOKEN`, `GITLAB_FLIP_REPO_ID`, and Algolia keys. Its `vitest` hangs without them, so use `yarn test --filter='!swirl-docs'` for the library packages.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-899dea48-9017-4d58-8593-c95a3ad69dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-899dea48-9017-4d58-8593-c95a3ad69dd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

