### PR TITLE
fix(swirl-tree-navigation-item): update mark-as-new tag styling (BUI-375)

### DIFF
--- a/packages/swirl-components/src/components/swirl-tree-navigation-item/swirl-tree-navigation-item.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-navigation-item/swirl-tree-navigation-item.tsx
@@ -210,10 +210,10 @@ export class SwirlTreeNavigationItem {
               {this.markAsNew && (
                 <swirl-tag
                   class="tree-navigation-item__is-new-tag"
-                  intent="info"
+                  intent="default"
                   label={this.markAsNewLabel}
-                  size="m"
-                  variant="default"
+                  size="s"
+                  variant="strong"
                 ></swirl-tag>
               )}
             </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `swirl-tree-navigation-item` mark-as-new tag styling to match design specs.

### Changes

Updates the `swirl-tag` used for the mark-as-new badge in `swirl-tree-navigation-item`:

| Property | Before | After |
|----------|--------|-------|
| Size | `m` | `s` |
| Intent | `info` | `default` |
| Variant | `default` | `strong` |

## Test plan

- [ ] Verify mark-as-new tag renders with updated size, intent, and variant in Storybook
- [ ] Confirm tag styling matches design specs for tree navigation items
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42e0ef52-d483-4f98-8d7b-b4e06c6cb5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42e0ef52-d483-4f98-8d7b-b4e06c6cb5ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

