### PR TITLE
Fix swirl thumbnail remove prop collision

### DIFF
--- a/.changeset/poor-horses-invite.md
+++ b/.changeset/poor-horses-invite.md
@@ -1,0 +1,9 @@
+---
+"@getflip/swirl-ai": patch
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Rename `remove` event to `removeThumbnail` to avoid conflicts with native
+`HTMLElement.remove` function

--- a/packages/swirl-components/src/components/swirl-thumbnail/swirl-thumbnail.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-thumbnail/swirl-thumbnail.spec.tsx
@@ -40,6 +40,16 @@ describe("swirl-thumbnail", () => {
     ).toBe("https://picsum.photos/id/433/400/400");
   });
 
+  it("preserves native Element.remove on the host", async () => {
+    const page = await newSpecPage({
+      components: [SwirlThumbnail],
+      html: `<swirl-thumbnail alt="x" src="/x.png"></swirl-thumbnail>`,
+    });
+
+    expect(typeof page.root.remove).toBe("function");
+    expect(page.root.remove).toBe(HTMLElement.prototype.remove);
+  });
+
   it("renders a segmented button group on larger sizes", async () => {
     const page = await newSpecPage({
       components: [SwirlThumbnail],

--- a/packages/swirl-components/src/components/swirl-thumbnail/swirl-thumbnail.tsx
+++ b/packages/swirl-components/src/components/swirl-thumbnail/swirl-thumbnail.tsx
@@ -44,7 +44,7 @@ export class SwirlThumbnail {
   @Prop() timestamp?: string;
 
   @Event() edit: EventEmitter<MouseEvent>;
-  @Event() remove: EventEmitter<MouseEvent>;
+  @Event({ eventName: "remove" }) removeThumbnail?: EventEmitter<MouseEvent>;
   @Event() thumbnailClick: EventEmitter<MouseEvent>;
 
   @State() hasHover: boolean = true;
@@ -85,7 +85,7 @@ export class SwirlThumbnail {
   };
 
   private onRemoveClick = (event: MouseEvent) => {
-    this.remove.emit(event);
+    this.removeThumbnail.emit(event);
     this.popoverEl?.close();
   };
 
@@ -213,7 +213,7 @@ export class SwirlThumbnail {
                     hideLabel
                     icon={this.removeButtonIcon}
                     label={this.removeButtonLabel}
-                    onClick={this.remove.emit}
+                    onClick={this.removeThumbnail.emit}
                     variant="on-image"
                   ></swirl-button>
                 </span>
@@ -231,7 +231,7 @@ export class SwirlThumbnail {
                 }
                 class="thumbnail__compact-button"
                 onClick={
-                  showCompactEditButton ? this.edit.emit : this.remove.emit
+                  showCompactEditButton ? this.edit.emit : this.removeThumbnail.emit
                 }
                 type="button"
               >


### PR DESCRIPTION
## Summary

Rename `remove` event to `removeThumbnail` to avoid conflicts with native `HTMLElement.remove` function

- [Ticket](#)
- [Design](#)
- [Storybook](#)
