### PR TITLE
Tweak popover trigger intersection behaviour

### DIFF
--- a/.changeset/purple-yaks-promise.md
+++ b/.changeset/purple-yaks-promise.md
@@ -1,0 +1,6 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Only automatically hide a swirl-popover when its swirl-popover-trigger is
+completely scrolled out of view

--- a/packages/swirl-components/src/components/swirl-popover-trigger/swirl-popover-trigger.tsx
+++ b/packages/swirl-components/src/components/swirl-popover-trigger/swirl-popover-trigger.tsx
@@ -90,7 +90,7 @@ export class SwirlPopoverTrigger {
         this.onVisibilityChange.bind(this),
         {
           root: this.parentScrollContainer,
-          threshold: 1,
+          threshold: 0,
         }
       );
 


### PR DESCRIPTION
Only automatically hide a popover when the trigger is completely hidden from view

## Summary

- [Ticket](https://linear.app/flip/issue/ENG-4207/post-in-grid-view-doesnt-allow-to-select-reactions-other-than-thumbs)