### PR TITLE
Fix a Chrome issue causing popovers inside cards to flicker

### DIFF
--- a/.changeset/twelve-ducks-deny.md
+++ b/.changeset/twelve-ducks-deny.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix a Chrome issue causing swirl-popovers inside swirl-cards to flicker

--- a/packages/swirl-components/src/styles/global.css
+++ b/packages/swirl-components/src/styles/global.css
@@ -133,7 +133,8 @@ dt {
  * hovered or focused. This style ensures that the popover is clickable even if
  * the item is not hovered or focused.
 */
-swirl-resource-list-item swirl-popover {
+swirl-resource-list-item swirl-popover,
+swirl-card swirl-popover {
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ENG-4221/post-grid-item-tools-popover-issue)
