### PR TITLE
fix: data cell intent background colors

### DIFF
--- a/.changeset/five-steaks-protect.md
+++ b/.changeset/five-steaks-protect.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Fix data cell intent background colors

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -6976,7 +6976,7 @@
             {
               "name": "intent",
               "type": {
-                "text": "\"critical\" | \"default\" | \"info\" | \"special\" | \"success\" | \"translucent\" | \"warning\"",
+                "text": "\"critical\" | \"default\" | \"info\" | \"special\" | \"subdued\" | \"success\" | \"translucent\" | \"warning\"",
                 "references": [
                   {
                     "name": "SwirlDataCellIntent"
@@ -7021,7 +7021,7 @@
               "kind": "field",
               "name": "intent",
               "type": {
-                "text": "\"critical\" | \"default\" | \"info\" | \"special\" | \"success\" | \"translucent\" | \"warning\"",
+                "text": "\"critical\" | \"default\" | \"info\" | \"special\" | \"subdued\" | \"success\" | \"translucent\" | \"warning\"",
                 "references": [
                   {
                     "name": "SwirlDataCellIntent"

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
@@ -15,7 +15,6 @@
   gap: var(--s-space-8);
   width: 100%;
   padding: var(--s-space-12) var(--s-space-16);
-  background-color: var(--s-surface-raised-50-default);
   border-radius: var(--swirl-data-cell-border-radius, var(--s-border-radius-l));
 }
 
@@ -25,7 +24,7 @@
 
 /* Intent backgrounds */
 .data-cell--intent-default {
-  background-color: var(--swirl-tag-background-default);
+  background-color: var(--s-surface-raised-50-default);
 }
 
 .data-cell--intent-info {
@@ -50,6 +49,10 @@
 
 .data-cell--intent-translucent {
   background-color: var(--s-surface-on-image-default);
+}
+
+.data-cell--intent-subdued {
+  background-color: var(--s-surface-raised-default);
 }
 
 .data-cell--vertical {

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.tsx
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.tsx
@@ -17,7 +17,8 @@ export type SwirlDataCellIntent =
   | "success"
   | "info"
   | "special"
-  | "translucent";
+  | "translucent"
+  | "subdued";
 
 /**
  * @slot media - Optional media content (e.g., swirl-avatar, icons). Only swirl-avatar and icon elements are styled.

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -2774,6 +2774,9 @@
               "name": "special"
             },
             {
+              "name": "subdued"
+            },
+            {
               "name": "success"
             },
             {


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ACT-3579/swirl-fix-data-cell-intent-background-colors)
- [Design](#)
- [Storybook](#)

If necessary you can **[check here](https://www.figma.com/design/zI4W3OiXq6Lnr7QwYcNaFB/Paswordless-Login-via-Passkeys?node-id=868-42368&m=dev)** the cells background colors.
Take SSO as an example, the parent cell uses a lighter grey `var(--s-surface-raised-50-default)` and the children use a darker one with `var(--s-surface-raised-default)`

https://github.com/user-attachments/assets/4cf3a35b-705a-4e6d-b398-82cbd6688cc9
