### PR TITLE
chore: add dependabot config for security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/*"
+      - "/apps/*"
+    schedule:
+      interval: "weekly"
+    # 0 disables version-update PRs; security updates are unaffected
+    open-pull-requests-limit: 0
+    groups:
+      security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with security-only updates (`open-pull-requests-limit: 0` disables routine version bumps)
- Group all security advisories into a single weekly PR via the `security` group
- Covers root, `packages/*`, and `apps/*` workspace directories

## Context
Closes the stale overlapping Dependabot security PR backlog (#1689, #1688, #1687, #1686, #1651, #1565) which bundled breaking majors and failed CI. After merge, those PRs will be closed so Dependabot can regenerate clean, scoped security PRs.

## Test plan
- [x] Config matches Dependabot v2 schema
- [ ] Merge and close stale Dependabot PRs
- [ ] Verify Dependabot opens a fresh grouped security PR


Made with [Cursor](https://cursor.com)