### PR TITLE
Console layout: collapsible sidebar + new swirl-sidebar-navigation

### DIFF
--- a/.changeset/sidebar-navigation-console-layout.md
+++ b/.changeset/sidebar-navigation-console-layout.md
@@ -1,0 +1,15 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Add `swirl-sidebar-navigation` component and redesign `swirl-console-layout` with a hideable, collapsible sidebar.
+
+**New component `swirl-sidebar-navigation`** — reusable 296px sidebar shell (logo slot with Flip fallback, `appName`, collapse button emitting `collapseButtonClick`, scrollable default slot with scroll-state header/footer dividers, `user` footer slot, `elevated` shadow variant, `focusCollapseButton()` method).
+
+**`swirl-console-layout` changes** (API is backward compatible, behavior notes below):
+
+- New shell styling: an ambient radial-glow background on a sunken surface (themeable via `--swirl-console-layout-background`), a rounded content card, and a translucent 296px sidebar rendered through `swirl-sidebar-navigation`.
+- The desktop sidebar can now be hidden via its collapse button and reopened via a floating menu button (or the app bar toggle when an app bar is visible). New event `sidebarVisibilityChange(boolean)`; new slot `logo`.
+- The visibility state persists to localStorage. The default key is shared per origin — set `sidebarVisibilityStateStorageKey` per app if multiple Swirl console apps run on the same origin.
+- Behavior change: `toggleSidebar()`/`showSidebar()`/`hideSidebar()` now also hide/show the sidebar on desktop viewports (previously mobile-only). If you call `hideSidebar()` on route changes to close the mobile drawer, guard it with a viewport check to keep the desktop sidebar open.
+- The mobile drawer is now full-height and overlays the app bar while open.

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -6704,6 +6704,14 @@
               "fieldName": "showNavigationButtonLabel"
             },
             {
+              "name": "sidebar-visibility-state-storage-key",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE\"",
+              "fieldName": "sidebarVisibilityStateStorageKey"
+            },
+            {
               "name": "subheading",
               "type": {
                 "text": "string"
@@ -6828,6 +6836,16 @@
             },
             {
               "kind": "field",
+              "name": "sidebarVisibilityStateStorageKey",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE\"",
+              "readonly": true,
+              "attribute": "sidebar-visibility-state-storage-key"
+            },
+            {
+              "kind": "field",
               "name": "subheading",
               "type": {
                 "text": "string"
@@ -6838,7 +6856,7 @@
             {
               "kind": "method",
               "name": "hideSidebar",
-              "description": "Hide the mobile navigation.",
+              "description": "Hide the sidebar.",
               "return": {
                 "type": {
                   "text": "Promise<void>",
@@ -6854,7 +6872,7 @@
             {
               "kind": "method",
               "name": "showSidebar",
-              "description": "Show the mobile navigation.",
+              "description": "Show the sidebar.",
               "return": {
                 "type": {
                   "text": "Promise<void>",
@@ -6870,7 +6888,7 @@
             {
               "kind": "method",
               "name": "toggleSidebar",
-              "description": "Toggle the mobile navigation visibility.",
+              "description": "Toggle the sidebar visibility.",
               "return": {
                 "type": {
                   "text": "Promise<void>",
@@ -6908,6 +6926,12 @@
                   }
                 ]
               }
+            },
+            {
+              "name": "sidebarVisibilityChange",
+              "type": {
+                "text": "CustomEvent<boolean>"
+              }
             }
           ],
           "slots": [
@@ -6930,6 +6954,10 @@
             {
               "name": "heading",
               "description": "The main content's heading (only rendered if \"heading\" prop is not set)."
+            },
+            {
+              "name": "logo",
+              "description": "Custom logo (forwarded to the sidebar navigation)"
             },
             {
               "name": "navigation",
@@ -49284,6 +49312,170 @@
           "name": "swirl-shell-navigation-item",
           "declaration": {
             "name": "SwirlShellNavigationItem"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.tsx",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "swirl-sidebar-navigation",
+          "name": "SwirlSidebarNavigation",
+          "attributes": [
+            {
+              "name": "app-name",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "appName"
+            },
+            {
+              "name": "collapse-button-label",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Hide navigation\"",
+              "fieldName": "collapseButtonLabel"
+            },
+            {
+              "name": "elevated",
+              "type": {
+                "text": "boolean"
+              },
+              "fieldName": "elevated"
+            },
+            {
+              "name": "hide-collapse-button",
+              "type": {
+                "text": "boolean"
+              },
+              "fieldName": "hideCollapseButton"
+            },
+            {
+              "name": "navigation-label",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Main\"",
+              "fieldName": "navigationLabel"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "appName",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "app-name"
+            },
+            {
+              "kind": "field",
+              "name": "collapseButtonLabel",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Hide navigation\"",
+              "readonly": true,
+              "attribute": "collapse-button-label"
+            },
+            {
+              "kind": "field",
+              "name": "elevated",
+              "type": {
+                "text": "boolean"
+              },
+              "readonly": true,
+              "attribute": "elevated"
+            },
+            {
+              "kind": "field",
+              "name": "hideCollapseButton",
+              "type": {
+                "text": "boolean"
+              },
+              "readonly": true,
+              "attribute": "hide-collapse-button"
+            },
+            {
+              "kind": "field",
+              "name": "navigationLabel",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"Main\"",
+              "readonly": true,
+              "attribute": "navigation-label"
+            },
+            {
+              "kind": "method",
+              "name": "focusCollapseButton",
+              "description": "Focus the collapse button.",
+              "return": {
+                "type": {
+                  "text": "Promise<void>",
+                  "references": [
+                    {
+                      "name": "Promise",
+                      "package": "global:"
+                    },
+                    {
+                      "name": "HTMLButtonElement",
+                      "package": "global:"
+                    }
+                  ]
+                }
+              }
+            }
+          ],
+          "events": [
+            {
+              "name": "collapseButtonClick",
+              "type": {
+                "text": "CustomEvent<MouseEvent>",
+                "references": [
+                  {
+                    "name": "MouseEvent",
+                    "package": "global:"
+                  }
+                ]
+              }
+            }
+          ],
+          "slots": [
+            {
+              "name": "(default)",
+              "description": "Navigation content (e.g. swirl-tree-navigation)"
+            },
+            {
+              "name": "logo",
+              "description": "Custom logo/brand mark shown in the header (32×32). Falls back to the Flip logo mark."
+            },
+            {
+              "name": "user",
+              "description": "User profile content pinned to the bottom"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SwirlSidebarNavigation",
+          "declaration": {
+            "name": "SwirlSidebarNavigation"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "swirl-sidebar-navigation",
+          "declaration": {
+            "name": "SwirlSidebarNavigation"
           }
         }
       ]

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -822,7 +822,7 @@ export namespace Components {
          */
         "hideNavigationButtonLabel"?: string;
         /**
-          * Hide the mobile navigation.
+          * Hide the sidebar.
          */
         "hideSidebar": () => Promise<void>;
         /**
@@ -841,12 +841,16 @@ export namespace Components {
          */
         "showNavigationButtonLabel"?: string;
         /**
-          * Show the mobile navigation.
+          * Show the sidebar.
          */
         "showSidebar": () => Promise<void>;
+        /**
+          * @default "SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE"
+         */
+        "sidebarVisibilityStateStorageKey"?: string;
         "subheading"?: string;
         /**
-          * Toggle the mobile navigation visibility.
+          * Toggle the sidebar visibility.
          */
         "toggleSidebar": () => Promise<void>;
     }
@@ -4393,6 +4397,23 @@ export namespace Components {
         "variant": SwirlShellNavigationItemVariant;
         "withGradient"?: boolean;
     }
+    interface SwirlSidebarNavigation {
+        "appName"?: string;
+        /**
+          * @default "Hide navigation"
+         */
+        "collapseButtonLabel"?: string;
+        "elevated"?: boolean;
+        /**
+          * Focus the collapse button.
+         */
+        "focusCollapseButton": () => Promise<void>;
+        "hideCollapseButton"?: boolean;
+        /**
+          * @default "Main"
+         */
+        "navigationLabel"?: string;
+    }
     interface SwirlSkeletonBox {
         /**
           * @default true
@@ -5901,6 +5922,10 @@ export interface SwirlShellLayoutCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSwirlShellLayoutElement;
 }
+export interface SwirlSidebarNavigationCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSwirlSidebarNavigationElement;
+}
 export interface SwirlSwitchCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSwirlSwitchElement;
@@ -6260,6 +6285,7 @@ declare global {
     interface HTMLSwirlConsoleLayoutElementEventMap {
         "backButtonClick": MouseEvent;
         "helpButtonClick": MouseEvent;
+        "sidebarVisibilityChange": boolean;
     }
     interface HTMLSwirlConsoleLayoutElement extends Components.SwirlConsoleLayout, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSwirlConsoleLayoutElementEventMap>(type: K, listener: (this: HTMLSwirlConsoleLayoutElement, ev: SwirlConsoleLayoutCustomEvent<HTMLSwirlConsoleLayoutElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -8626,6 +8652,23 @@ declare global {
         prototype: HTMLSwirlShellNavigationItemElement;
         new (): HTMLSwirlShellNavigationItemElement;
     };
+    interface HTMLSwirlSidebarNavigationElementEventMap {
+        "collapseButtonClick": MouseEvent;
+    }
+    interface HTMLSwirlSidebarNavigationElement extends Components.SwirlSidebarNavigation, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSwirlSidebarNavigationElementEventMap>(type: K, listener: (this: HTMLSwirlSidebarNavigationElement, ev: SwirlSidebarNavigationCustomEvent<HTMLSwirlSidebarNavigationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSwirlSidebarNavigationElementEventMap>(type: K, listener: (this: HTMLSwirlSidebarNavigationElement, ev: SwirlSidebarNavigationCustomEvent<HTMLSwirlSidebarNavigationElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLSwirlSidebarNavigationElement: {
+        prototype: HTMLSwirlSidebarNavigationElement;
+        new (): HTMLSwirlSidebarNavigationElement;
+    };
     interface HTMLSwirlSkeletonBoxElement extends Components.SwirlSkeletonBox, HTMLStencilElement {
     }
     var HTMLSwirlSkeletonBoxElement: {
@@ -10056,6 +10099,7 @@ declare global {
         "swirl-separator": HTMLSwirlSeparatorElement;
         "swirl-shell-layout": HTMLSwirlShellLayoutElement;
         "swirl-shell-navigation-item": HTMLSwirlShellNavigationItemElement;
+        "swirl-sidebar-navigation": HTMLSwirlSidebarNavigationElement;
         "swirl-skeleton-box": HTMLSwirlSkeletonBoxElement;
         "swirl-skeleton-text": HTMLSwirlSkeletonTextElement;
         "swirl-spinner": HTMLSwirlSpinnerElement;
@@ -10840,12 +10884,17 @@ declare namespace LocalJSX {
         "navigationLabel"?: string;
         "onBackButtonClick"?: (event: SwirlConsoleLayoutCustomEvent<MouseEvent>) => void;
         "onHelpButtonClick"?: (event: SwirlConsoleLayoutCustomEvent<MouseEvent>) => void;
+        "onSidebarVisibilityChange"?: (event: SwirlConsoleLayoutCustomEvent<boolean>) => void;
         "showBackButton"?: boolean;
         "showHelpButton"?: boolean;
         /**
           * @default "Show main navigation"
          */
         "showNavigationButtonLabel"?: string;
+        /**
+          * @default "SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE"
+         */
+        "sidebarVisibilityStateStorageKey"?: string;
         "subheading"?: string;
     }
     interface SwirlDataCell {
@@ -14294,6 +14343,20 @@ declare namespace LocalJSX {
         "variant"?: SwirlShellNavigationItemVariant;
         "withGradient"?: boolean;
     }
+    interface SwirlSidebarNavigation {
+        "appName"?: string;
+        /**
+          * @default "Hide navigation"
+         */
+        "collapseButtonLabel"?: string;
+        "elevated"?: boolean;
+        "hideCollapseButton"?: boolean;
+        /**
+          * @default "Main"
+         */
+        "navigationLabel"?: string;
+        "onCollapseButtonClick"?: (event: SwirlSidebarNavigationCustomEvent<MouseEvent>) => void;
+    }
     interface SwirlSkeletonBox {
         /**
           * @default true
@@ -15904,6 +15967,7 @@ declare namespace LocalJSX {
         "showBackButton": boolean;
         "showHelpButton": boolean;
         "showNavigationButtonLabel": string;
+        "sidebarVisibilityStateStorageKey": string;
         "subheading": string;
         "hideContentHeader": boolean;
     }
@@ -17813,6 +17877,13 @@ declare namespace LocalJSX {
         "variant": SwirlShellNavigationItemVariant;
         "withGradient": boolean;
     }
+    interface SwirlSidebarNavigationAttributes {
+        "appName": string;
+        "collapseButtonLabel": string;
+        "elevated": boolean;
+        "hideCollapseButton": boolean;
+        "navigationLabel": string;
+    }
     interface SwirlSkeletonBoxAttributes {
         "animated": boolean;
         "aspectRatio": string;
@@ -18799,6 +18870,7 @@ declare namespace LocalJSX {
         "swirl-separator": Omit<SwirlSeparator, keyof SwirlSeparatorAttributes> & { [K in keyof SwirlSeparator & keyof SwirlSeparatorAttributes]?: SwirlSeparator[K] } & { [K in keyof SwirlSeparator & keyof SwirlSeparatorAttributes as `attr:${K}`]?: SwirlSeparatorAttributes[K] } & { [K in keyof SwirlSeparator & keyof SwirlSeparatorAttributes as `prop:${K}`]?: SwirlSeparator[K] };
         "swirl-shell-layout": Omit<SwirlShellLayout, keyof SwirlShellLayoutAttributes> & { [K in keyof SwirlShellLayout & keyof SwirlShellLayoutAttributes]?: SwirlShellLayout[K] } & { [K in keyof SwirlShellLayout & keyof SwirlShellLayoutAttributes as `attr:${K}`]?: SwirlShellLayoutAttributes[K] } & { [K in keyof SwirlShellLayout & keyof SwirlShellLayoutAttributes as `prop:${K}`]?: SwirlShellLayout[K] };
         "swirl-shell-navigation-item": Omit<SwirlShellNavigationItem, keyof SwirlShellNavigationItemAttributes> & { [K in keyof SwirlShellNavigationItem & keyof SwirlShellNavigationItemAttributes]?: SwirlShellNavigationItem[K] } & { [K in keyof SwirlShellNavigationItem & keyof SwirlShellNavigationItemAttributes as `attr:${K}`]?: SwirlShellNavigationItemAttributes[K] } & { [K in keyof SwirlShellNavigationItem & keyof SwirlShellNavigationItemAttributes as `prop:${K}`]?: SwirlShellNavigationItem[K] } & OneOf<"label", SwirlShellNavigationItem["label"], SwirlShellNavigationItemAttributes["label"]>;
+        "swirl-sidebar-navigation": Omit<SwirlSidebarNavigation, keyof SwirlSidebarNavigationAttributes> & { [K in keyof SwirlSidebarNavigation & keyof SwirlSidebarNavigationAttributes]?: SwirlSidebarNavigation[K] } & { [K in keyof SwirlSidebarNavigation & keyof SwirlSidebarNavigationAttributes as `attr:${K}`]?: SwirlSidebarNavigationAttributes[K] } & { [K in keyof SwirlSidebarNavigation & keyof SwirlSidebarNavigationAttributes as `prop:${K}`]?: SwirlSidebarNavigation[K] };
         "swirl-skeleton-box": Omit<SwirlSkeletonBox, keyof SwirlSkeletonBoxAttributes> & { [K in keyof SwirlSkeletonBox & keyof SwirlSkeletonBoxAttributes]?: SwirlSkeletonBox[K] } & { [K in keyof SwirlSkeletonBox & keyof SwirlSkeletonBoxAttributes as `attr:${K}`]?: SwirlSkeletonBoxAttributes[K] } & { [K in keyof SwirlSkeletonBox & keyof SwirlSkeletonBoxAttributes as `prop:${K}`]?: SwirlSkeletonBox[K] };
         "swirl-skeleton-text": Omit<SwirlSkeletonText, keyof SwirlSkeletonTextAttributes> & { [K in keyof SwirlSkeletonText & keyof SwirlSkeletonTextAttributes]?: SwirlSkeletonText[K] } & { [K in keyof SwirlSkeletonText & keyof SwirlSkeletonTextAttributes as `attr:${K}`]?: SwirlSkeletonTextAttributes[K] } & { [K in keyof SwirlSkeletonText & keyof SwirlSkeletonTextAttributes as `prop:${K}`]?: SwirlSkeletonText[K] };
         "swirl-spinner": Omit<SwirlSpinner, keyof SwirlSpinnerAttributes> & { [K in keyof SwirlSpinner & keyof SwirlSpinnerAttributes]?: SwirlSpinner[K] } & { [K in keyof SwirlSpinner & keyof SwirlSpinnerAttributes as `attr:${K}`]?: SwirlSpinnerAttributes[K] } & { [K in keyof SwirlSpinner & keyof SwirlSpinnerAttributes as `prop:${K}`]?: SwirlSpinner[K] };
@@ -19317,6 +19389,7 @@ declare module "@stencil/core" {
              * @deprecated This component is deprecated and will be removed in the next major release.
              */
             "swirl-shell-navigation-item": LocalJSX.IntrinsicElements["swirl-shell-navigation-item"] & JSXBase.HTMLAttributes<HTMLSwirlShellNavigationItemElement>;
+            "swirl-sidebar-navigation": LocalJSX.IntrinsicElements["swirl-sidebar-navigation"] & JSXBase.HTMLAttributes<HTMLSwirlSidebarNavigationElement>;
             "swirl-skeleton-box": LocalJSX.IntrinsicElements["swirl-skeleton-box"] & JSXBase.HTMLAttributes<HTMLSwirlSkeletonBoxElement>;
             "swirl-skeleton-text": LocalJSX.IntrinsicElements["swirl-skeleton-text"] & JSXBase.HTMLAttributes<HTMLSwirlSkeletonTextElement>;
             "swirl-spinner": LocalJSX.IntrinsicElements["swirl-spinner"] & JSXBase.HTMLAttributes<HTMLSwirlSpinnerElement>;

--- a/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.css
+++ b/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.css
@@ -6,7 +6,7 @@
   height: 100vh;
   --console-footer-height: 4.25rem;
   --console-app-bar-height: 3.5rem;
-  --console-sidebar-width: 18.5rem;
+  --console-sidebar-width: 18.5rem; /* 296px */
 
   & * {
     box-sizing: border-box;
@@ -15,14 +15,34 @@
 
 .console-layout {
   display: grid;
+  overflow: hidden;
   width: 100%;
   height: 100%;
+  padding: var(--s-space-8);
+  background: var(
+    --swirl-console-layout-background,
+    radial-gradient(
+        140% 78% at 50% 116%,
+        rgba(20, 90, 245, 0.46) 0%,
+        rgba(20, 90, 245, 0) 68%
+      )
+      var(--s-surface-sunken-default)
+  );
+  gap: var(--s-space-8);
   grid-template-columns: 1fr;
+  /* Constrain the single row to the layout height so the inner areas stay
+     within the viewport and scroll internally instead of growing the layout */
+  grid-template-rows: minmax(0, 1fr);
   grid-template-areas: "main";
 
   @media (--from-tablet) {
+    transition: grid-template-columns 0.15s, gap 0.15s;
     grid-template-columns: var(--console-sidebar-width) 1fr;
     grid-template-areas: "sidebar main";
+  }
+
+  @media (prefers-reduced-motion) {
+    transition: none;
   }
 }
 
@@ -35,11 +55,28 @@
   }
 }
 
+.console-layout--sidebar-hidden {
+  @media (--from-tablet) {
+    gap: 0;
+    grid-template-columns: 0 1fr;
+
+    & .console-layout__sidebar {
+      visibility: hidden;
+      opacity: 0;
+      transform: translate3d(-100%, 0, 0);
+      /* Delay hiding until the slide-out finished; when showing, the base
+         transition applies and visibility flips back instantly so the
+         sidebar can receive focus right away */
+      transition: transform 0.15s, opacity 0.15s, visibility 0s linear 0.15s;
+    }
+  }
+}
+
 .console-layout--empty-app-bar {
   & .console-layout__main {
     @media (--from-tablet) {
       grid-template-areas: "content";
-      grid-template-rows: 1fr;
+      grid-template-rows: minmax(0, 1fr);
     }
   }
 
@@ -56,93 +93,140 @@
       grid-template-areas:
         "content"
         "footer";
-      grid-template-rows: 1fr min-content;
+      grid-template-rows: minmax(0, 1fr) min-content;
     }
   }
 }
 
 .console-layout__sidebar {
   position: fixed;
-  z-index: var(--s-z-30);
-  top: 4rem;
+  /* Above the sticky app bar (z-30) so the full-height drawer is not
+     covered by it on mobile */
+  z-index: var(--s-z-40);
+  top: 0;
   bottom: 0;
   left: 0;
-  display: grid;
-  overflow-x: hidden;
-  overflow-y: auto;
+  display: block;
   width: 100%;
-  max-width: 20rem;
-  border-right: var(--s-border-width-default) solid var(--s-border-default);
+  max-width: var(--console-sidebar-width);
   transition: transform 0.15s, box-shadow 0.15s;
   transform: translate3d(-100%, 0, 0);
-  grid-template-rows: auto 1fr min-content;
-  grid-template-areas:
-    "header"
-    "navigation"
-    "user";
 
-  @media (prefers-reduced-motion) {
-    transition: none;
+  @media (--to-tablet) {
+    --swirl-sidebar-navigation-background: var(--s-background-default);
+    --swirl-sidebar-navigation-border-radius: 0 var(--s-border-radius-l)
+      var(--s-border-radius-l) 0;
   }
 
   @media (--from-tablet) {
     position: static;
     top: auto;
     left: auto;
+    /* Fixed width keeps the content from reflowing while the grid column
+       animates; the transform slides the sidebar out in lockstep with the
+       shrinking column, clipped by the shell's overflow */
+    min-width: var(--console-sidebar-width);
+    /* Allow the sidebar grid cell to shrink so its nav scrolls internally
+       rather than stretching the layout to the navigation's full height */
+    min-height: 0;
     max-width: none;
     height: 100%;
+    transition: transform 0.15s, opacity 0.15s;
     transform: none;
     box-shadow: none;
     grid-area: sidebar;
   }
-}
 
-.console-layout__header {
-  overflow: hidden;
-  min-width: 0;
-  padding: var(--s-space-20) var(--s-space-24);
-  background-color: var(--s-background-default);
-  grid-area: header;
-}
-
-.console-layout__navigation {
-  overflow-x: hidden;
-  overflow-y: auto;
-  padding-top: var(--s-space-8);
-  padding-bottom: var(--s-space-8);
-  background-color: var(--s-background-default);
-  grid-area: navigation;
-}
-
-.console-layout__user {
-  overflow: hidden;
-  padding: var(--s-space-16) var(--s-space-24);
-  border-top: var(--s-border-width-default) solid var(--s-border-default);
-  background-color: var(--s-background-default);
-  grid-area: user;
-  min-height: var(--console-footer-height);
-  box-sizing: border-box;
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 .console-layout__main {
+  position: relative;
   display: grid;
   overflow: hidden;
   width: 100%;
   height: 100%;
+  /* Allow the grid cell to shrink below its content's intrinsic height so the
+     content area scrolls internally instead of stretching the layout */
+  min-height: 0;
+  border-radius: var(--s-border-radius-l);
+  background-color: var(--s-background-default);
   grid-area: main;
   gap: var(--s-border-width-default);
-  grid-template-rows: var(--console-app-bar-height) 1fr;
+  grid-template-rows: var(--console-app-bar-height) minmax(0, 1fr);
   grid-template-areas:
     "app-bar"
     "content";
 }
 
 .console-layout--has-footer .console-layout__main {
-  grid-template-rows: var(--console-app-bar-height) 1fr min-content;
+  grid-template-rows: var(--console-app-bar-height) minmax(0, 1fr) min-content;
   grid-template-areas:
     "app-bar"
     "content"
     "footer";
+}
+
+.console-layout__show-sidebar-button {
+  position: absolute;
+  z-index: var(--s-z-20);
+  top: var(--s-space-16);
+  left: var(--s-space-16);
+  display: none;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: var(--s-space-8);
+  align-items: center;
+  justify-content: center;
+  border: var(--s-border-width-default) solid
+    var(--s-border-translucent-outline);
+  border-radius: var(--s-border-radius-sm);
+  color: var(--s-icon-strong);
+  background-color: var(--s-translucent-medium-default);
+  backdrop-filter: blur(var(--s-blur-s));
+  -webkit-backdrop-filter: blur(var(--s-blur-s));
+  box-shadow: var(--s-shadow-level-2);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--s-translucent-medium-hovered);
+  }
+
+  &:active {
+    background-color: var(--s-translucent-medium-pressed);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    box-shadow: var(--s-shadow-level-2), 0 0 0 0.125rem var(--s-focus-default);
+  }
+
+  @media (--from-tablet) {
+    display: flex;
+  }
+}
+
+/* When the default app bar is visible, the sidebar toggle moves into it
+   instead of floating over the content */
+.console-layout:not(.console-layout--empty-app-bar):not(
+    .console-layout--has-custom-app-bar
+  )
+  .console-layout__show-sidebar-button {
+  @media (--from-tablet) {
+    display: none;
+  }
+}
+
+/* A custom app bar occupies the top edge; offset the floating button below it */
+.console-layout--has-custom-app-bar .console-layout__show-sidebar-button {
+  @media (--from-tablet) {
+    top: calc(var(--console-app-bar-height) + var(--s-space-16));
+  }
 }
 
 .console-layout__app-bar {
@@ -168,6 +252,14 @@
 .console-layout__mobile-navigation-button {
   @media (--from-tablet) {
     display: none;
+  }
+}
+
+/* Desktop: show the app bar toggle when the sidebar is hidden (the default
+   app bar is only rendered visible when appName/help button are set) */
+.console-layout--sidebar-hidden .console-layout__mobile-navigation-button {
+  @media (--from-tablet) {
+    display: inline-block;
   }
 }
 
@@ -220,27 +312,6 @@
   }
 
   width: 100%;
-}
-
-.console-layout__logo {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: var(--s-space-12);
-}
-
-.console-layout__logo-mark {
-  flex-shrink: 0;
-}
-
-.console-layout__logo-text {
-  min-width: 0;
-
-  &::part(text) {
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
 }
 
 .console-layout__content-header {

--- a/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.mdx
+++ b/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.mdx
@@ -6,7 +6,10 @@ import * as Stories from "./swirl-console-layout.stories";
 # SwirlConsoleLayout
 
 The SwirlConsoleLayout component provides the basic shell layout for the Flip
-admin tools.
+admin tools. The sidebar is rendered via
+[SwirlSidebarNavigation](?path=/docs/components-swirlsidebarnavigation--docs);
+the `navigation`, `user` and `logo` slots are forwarded to it, and the
+`logoText` prop sets the app name shown next to the logo.
 
 - **[Figma Design Specs](https://www.figma.com/file/Cks5hd1wSusGi1PYbpVgvX/Admindashboard?node-id=128%3A2201&t=RoIUBgbUhxFQOq8w-0)**
 - **[Source Code](https://github.com/flip-corp/swirl/tree/main/packages/swirl-components/src/components/swirl-console-layout)**
@@ -19,16 +22,36 @@ preview this component.
 
 <Controls of={Stories.SwirlConsoleLayout} />
 
+## Sidebar visibility
+
+On desktop viewports the sidebar can be expanded (default) or hidden. The
+sidebar's own collapse button hides it; a floating menu button at the top left
+of the content area (or the toggle in the default app bar, when visible) shows
+it again. The chosen state is persisted to localStorage under the key set via
+the `sidebarVisibilityStateStorageKey` prop and restored on load. When several
+admin apps run on the same origin, set a distinct key per app (e.g.
+`MY_APP_SIDEBAR_STATE`) so the apps don't overwrite each other's state. On
+mobile viewports the sidebar behaves as an off-canvas drawer toggled from the
+app bar; the drawer state is not persisted.
+
+Use the `toggleSidebar`, `showSidebar` and `hideSidebar` methods to control the
+sidebar programmatically. The methods affect both modes: on desktop they
+expand/hide the sidebar and persist the state, on mobile they open/close the
+drawer. Whenever the visibility changes — through user interaction or one of the
+methods — the `sidebarVisibilityChange` event is emitted with the new visibility
+as its payload. No event is emitted for the initial state on load.
+
 ## Related components
 
-No related components.
+[SwirlSidebarNavigation](?path=/docs/components-swirlsidebarnavigation--docs)
 
 ## Accessibility
 
-SwirlConsoleLayout is a layout shell with no ARIA attributes or
-keyboard-specific behavior. Ensure slotted navigation and content provide
+SwirlConsoleLayout is a layout shell with no keyboard-specific behavior of its
+own. A hidden sidebar is removed from the accessibility tree and focus order via
+`aria-hidden` and `inert`. Ensure slotted navigation and content provide
 appropriate semantics and focus management.
 
 ### Keyboard
 
-No component-specific keyboard behavior.
+On mobile viewports, pressing <kbd>Escape</kbd> closes the open sidebar drawer.

--- a/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.spec.tsx
@@ -2,7 +2,46 @@ import { newSpecPage } from "@stencil/core/testing";
 
 import { SwirlConsoleLayout } from "./swirl-console-layout";
 
+function mockMatchMedia(desktopViewport: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: query === "(min-width: 768px)" ? desktopViewport : false,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
+
+// "newSpecPage" resets the mock window, wiping its built-in storage. The mock
+// is installed as a non-enumerable own property, so it survives the reset and
+// allows seeding values before the page is created.
+function mockLocalStorage() {
+  const store = new Map<string, string>();
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (key: string) => (store.has(key) ? store.get(key) : null),
+      setItem: (key: string, value: string) => store.set(key, String(value)),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+    },
+  });
+}
+
 describe("swirl-console-layout", () => {
+  beforeEach(() => {
+    mockMatchMedia(true);
+    mockLocalStorage();
+  });
+
   it("renders its contents", async () => {
     const page = await newSpecPage({
       components: [SwirlConsoleLayout],
@@ -18,32 +57,18 @@ describe("swirl-console-layout", () => {
     expect(page.root).toEqualHtml(`
       <swirl-console-layout app-name="App name" heading="Heading">
         <mock:shadow-root>
-          <div class="console-layout">
-            <header aria-hidden="true" class="console-layout__sidebar" inert="">
-              <div class="console-layout__header">
-                <div class="console-layout__logo">
-                  <svg class="console-layout__logo-mark" fill="none" height="26" viewBox="0 0 301 460" width="16" xmlns="http://www.w3.org/2000/svg">
-                    <path clip-rule="evenodd" d="M2.52486 276.36C5.57709 289.149 11.02 301.094 18.2296 311.628L258.719 138.748C269.874 131.507 278.35 121.993 285.395 110.766C291.904 100.212 296.922 87.3014 298.875 74.6738C300.769 61.4277 300.809 48.353 297.757 35.5639C294.705 22.7748 289.262 10.8302 282.052 0.296051L41.5626 173.176C30.4077 180.417 21.9314 189.931 14.8867 201.158C8.37746 211.712 3.35926 224.623 1.40724 237.25C-0.544773 249.878 0.0338964 262.896 2.52486 276.36ZM80.3121 424.184C83.3644 436.973 88.8073 448.918 96.0169 459.452L229.113 363.743C240.268 356.502 248.744 346.988 255.789 335.761C262.298 325.207 267.317 312.296 269.269 299.668C271.164 286.422 271.203 273.348 268.151 260.559C265.099 247.769 259.656 235.825 252.446 225.291L119.35 320.999C108.195 328.24 99.7187 337.755 92.674 348.982C86.1647 359.535 81.1465 372.446 79.1945 385.074C77.2996 398.32 77.2599 411.395 80.3121 424.184Z" fill="#2151F5" fill-rule="evenodd"></path>
-                  </svg>
-                  <swirl-text class="console-layout__logo-text" weight="medium">
-                    Admin
-                  </swirl-text>
-                </div>
-              </div>
-              <nav aria-label="Main" class="console-layout__navigation">
-                <slot name="navigation"></slot>
-              </nav>
-              <div class="console-layout__user">
-                <slot name="user"></slot>
-              </div>
-            </header>
+          <div class="console-layout console-layout--sidebar-active">
+            <swirl-sidebar-navigation appname="Admin" aria-hidden="false" class="console-layout__sidebar" collapsebuttonlabel="Hide main navigation" id="sidebar" navigationlabel="Main">
+              <slot name="navigation"></slot>
+              <slot name="user" slot="user"></slot>
+            </swirl-sidebar-navigation>
             <main aria-labelledby="app-name" class="console-layout__main">
               <header class="console-layout__app-bar console-layout__app-bar--custom">
                 <slot name="app-bar"></slot>
               </header>
               <header class="console-layout__app-bar">
                 <span class="console-layout__mobile-navigation-button">
-                  <swirl-button hidelabel="" icon="<swirl-icon-menu></swirl-icon-menu>" label="Show main navigation" swirlariaexpanded="false"></swirl-button>
+                  <swirl-button hidelabel="" icon="<swirl-icon-close></swirl-icon-close>" label="Hide main navigation" swirlariaexpanded="true"></swirl-button>
                 </span>
                 <div class="console-layout__app-name">
                   <swirl-heading as="h1" headingid="app-name" level="4" text="App name"></swirl-heading>
@@ -130,6 +155,129 @@ describe("swirl-console-layout", () => {
       .click();
 
     expect(spy).toHaveBeenCalled();
+  });
+
+  it("hides the sidebar when its collapse button is clicked", async () => {
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    const spy = jest.fn();
+
+    page.root.addEventListener("sidebarVisibilityChange", spy);
+
+    const sidebar = page.root.shadowRoot.querySelector(
+      "swirl-sidebar-navigation"
+    );
+
+    expect(page.root.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-active"
+    );
+
+    expect(
+      page.root.shadowRoot.querySelector(".console-layout__show-sidebar-button")
+    ).toBeNull();
+
+    sidebar.dispatchEvent(new CustomEvent("collapseButtonClick"));
+    await page.waitForChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toBe(false);
+
+    expect(page.root.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-hidden"
+    );
+
+    expect(sidebar.getAttribute("aria-hidden")).toBe("true");
+    expect(sidebar.hasAttribute("inert")).toBe(true);
+
+    expect(
+      page.root.shadowRoot.querySelector(".console-layout__show-sidebar-button")
+    ).not.toBeNull();
+
+    expect(localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")).toBe(
+      "false"
+    );
+  });
+
+  it("shows the sidebar when the floating show button is clicked", async () => {
+    localStorage.setItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE", "false");
+
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    const spy = jest.fn();
+
+    page.root.addEventListener("sidebarVisibilityChange", spy);
+
+    page.root.shadowRoot
+      .querySelector<HTMLButtonElement>(".console-layout__show-sidebar-button")
+      .click();
+    await page.waitForChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toBe(true);
+
+    expect(page.root.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-active"
+    );
+
+    const sidebar = page.root.shadowRoot.querySelector(
+      "swirl-sidebar-navigation"
+    );
+
+    expect(sidebar.getAttribute("aria-hidden")).toBe("false");
+    expect(sidebar.hasAttribute("inert")).toBe(false);
+
+    expect(
+      page.root.shadowRoot.querySelector(".console-layout__show-sidebar-button")
+    ).toBeNull();
+
+    expect(localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")).toBe(
+      "true"
+    );
+  });
+
+  it("restores the hidden sidebar state from localStorage", async () => {
+    localStorage.setItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE", "false");
+
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    expect(page.root.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-hidden"
+    );
+
+    const sidebar = page.root.shadowRoot.querySelector(
+      "swirl-sidebar-navigation"
+    );
+
+    expect(sidebar.getAttribute("aria-hidden")).toBe("true");
+    expect(sidebar.hasAttribute("inert")).toBe(true);
+
+    expect(
+      page.root.shadowRoot.querySelector(".console-layout__show-sidebar-button")
+    ).not.toBeNull();
   });
 
   it("renders custom app bar slot and hides default app bar", async () => {
@@ -224,6 +372,343 @@ describe("swirl-console-layout", () => {
       "console-layout--has-custom-app-bar"
     );
     expect(layoutContainer).not.toHaveClass("console-layout--has-footer");
+  });
+
+  it("toggles the off-canvas sidebar on mobile viewports without persisting the state", async () => {
+    mockMatchMedia(false);
+
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    const layout = page.root as HTMLSwirlConsoleLayoutElement;
+    const layoutContainer =
+      layout.shadowRoot.querySelector<HTMLElement>(".console-layout");
+    const sidebar = layout.shadowRoot.querySelector("swirl-sidebar-navigation");
+
+    const spy = jest.fn();
+
+    layout.addEventListener("sidebarVisibilityChange", spy);
+
+    // The drawer starts closed
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-hidden");
+    expect(sidebar.getAttribute("aria-hidden")).toBe("true");
+    expect(sidebar.hasAttribute("inert")).toBe(true);
+
+    // toggleSidebar() opens the drawer
+    await layout.toggleSidebar();
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-active");
+    expect(sidebar.getAttribute("aria-hidden")).toBe("false");
+    expect(sidebar.hasAttribute("inert")).toBe(false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toBe(true);
+
+    // Escape closes the drawer
+    layoutContainer.dispatchEvent(
+      new KeyboardEvent("keydown", { code: "Escape" })
+    );
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-hidden");
+    expect(sidebar.hasAttribute("inert")).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[1][0].detail).toBe(false);
+
+    // The app bar toggle reopens the drawer; its bubbling click must not
+    // immediately close the drawer again via the outside click handler
+    layout.shadowRoot
+      .querySelector<HTMLElement>(
+        ".console-layout__mobile-navigation-button swirl-button"
+      )
+      .click();
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-active");
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy.mock.calls[2][0].detail).toBe(true);
+
+    // A click outside the sidebar closes the drawer
+    layout.shadowRoot
+      .querySelector<HTMLElement>(".console-layout__content")
+      .click();
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-hidden");
+    expect(sidebar.hasAttribute("inert")).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(4);
+    expect(spy.mock.calls[3][0].detail).toBe(false);
+
+    // The mobile drawer state is never persisted
+    expect(
+      localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")
+    ).toBeNull();
+  });
+
+  it("does not emit sidebarVisibilityChange for the initial visible state", async () => {
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: "<div></div>",
+    });
+
+    const spy = jest.fn();
+
+    // Attach the listener to the document before the component is created, so
+    // any emission during initial load would be caught
+    page.doc.addEventListener("sidebarVisibilityChange", spy);
+
+    await page.setContent(`
+      <swirl-console-layout app-name="App name" heading="Heading">
+        <div slot="navigation">Navigation</div>
+        <div slot="content">Content</div>
+      </swirl-console-layout>
+    `);
+    await page.waitForChanges();
+
+    const layout = page.body.querySelector<HTMLSwirlConsoleLayoutElement>(
+      "swirl-console-layout"
+    );
+
+    // Sanity check: the component is hydrated with the sidebar visible
+    expect(layout.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-active"
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+
+    // Sanity check: the document level listener does catch actual changes
+    await layout.hideSidebar();
+    await page.waitForChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toBe(false);
+  });
+
+  it("does not emit sidebarVisibilityChange when restoring a hidden sidebar on load", async () => {
+    localStorage.setItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE", "false");
+
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: "<div></div>",
+    });
+
+    const spy = jest.fn();
+
+    page.doc.addEventListener("sidebarVisibilityChange", spy);
+
+    await page.setContent(`
+      <swirl-console-layout app-name="App name" heading="Heading">
+        <div slot="navigation">Navigation</div>
+        <div slot="content">Content</div>
+      </swirl-console-layout>
+    `);
+    await page.waitForChanges();
+
+    const layout = page.body.querySelector<HTMLSwirlConsoleLayoutElement>(
+      "swirl-console-layout"
+    );
+    const sidebar = layout.shadowRoot.querySelector("swirl-sidebar-navigation");
+
+    // Sanity check: the component is hydrated with the sidebar hidden
+    expect(layout.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-hidden"
+    );
+    expect(sidebar.hasAttribute("inert")).toBe(true);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("deactivates the sidebar when resizing to mobile and restores the stored state when resizing back to desktop", async () => {
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    const layoutContainer =
+      page.root.shadowRoot.querySelector<HTMLElement>(".console-layout");
+    const sidebar = page.root.shadowRoot.querySelector(
+      "swirl-sidebar-navigation"
+    );
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-active");
+
+    // Resizing to a mobile viewport deactivates the sidebar
+    mockMatchMedia(false);
+    window.dispatchEvent(new Event("resize"));
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-hidden");
+    expect(sidebar.hasAttribute("inert")).toBe(true);
+
+    // Deactivating via resize must not overwrite the stored desktop state
+    expect(
+      localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")
+    ).toBeNull();
+
+    // Resizing back to a desktop viewport restores the stored state
+    localStorage.setItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE", "true");
+    mockMatchMedia(true);
+    window.dispatchEvent(new Event("resize"));
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-active");
+    expect(sidebar.hasAttribute("inert")).toBe(false);
+  });
+
+  it("controls the desktop sidebar via the public methods and persists the state", async () => {
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    const layout = page.root as HTMLSwirlConsoleLayoutElement;
+    const layoutContainer =
+      layout.shadowRoot.querySelector<HTMLElement>(".console-layout");
+
+    const spy = jest.fn();
+
+    layout.addEventListener("sidebarVisibilityChange", spy);
+
+    await layout.hideSidebar();
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-hidden");
+    expect(localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")).toBe(
+      "false"
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toBe(false);
+
+    // Hiding an already hidden sidebar is a no-op
+    await layout.hideSidebar();
+    await page.waitForChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    await layout.showSidebar();
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-active");
+    expect(localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")).toBe(
+      "true"
+    );
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[1][0].detail).toBe(true);
+
+    // Showing an already visible sidebar is a no-op
+    await layout.showSidebar();
+    await page.waitForChanges();
+
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // toggleSidebar() flips the state back and forth
+    await layout.toggleSidebar();
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-hidden");
+    expect(localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")).toBe(
+      "false"
+    );
+
+    await layout.toggleSidebar();
+    await page.waitForChanges();
+
+    expect(layoutContainer).toHaveClass("console-layout--sidebar-active");
+    expect(localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")).toBe(
+      "true"
+    );
+
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+
+  it("starts with a visible sidebar when no state is stored", async () => {
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    expect(
+      localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")
+    ).toBeNull();
+
+    expect(page.root.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-active"
+    );
+  });
+
+  it("starts with a visible sidebar when the stored value is unknown", async () => {
+    localStorage.setItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE", "banana");
+
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    const sidebar = page.root.shadowRoot.querySelector(
+      "swirl-sidebar-navigation"
+    );
+
+    expect(page.root.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-active"
+    );
+    expect(sidebar.hasAttribute("inert")).toBe(false);
+  });
+
+  it("persists the sidebar state under a custom storage key", async () => {
+    localStorage.setItem("CUSTOM_SIDEBAR_KEY", "false");
+
+    const page = await newSpecPage({
+      components: [SwirlConsoleLayout],
+      html: `
+        <swirl-console-layout app-name="App name" heading="Heading" sidebar-visibility-state-storage-key="CUSTOM_SIDEBAR_KEY">
+          <div slot="navigation">Navigation</div>
+          <div slot="content">Content</div>
+        </swirl-console-layout>
+      `,
+    });
+
+    const layout = page.root as HTMLSwirlConsoleLayoutElement;
+
+    // The initial state is read from the custom key
+    expect(layout.shadowRoot.querySelector(".console-layout")).toHaveClass(
+      "console-layout--sidebar-hidden"
+    );
+
+    await layout.showSidebar();
+    await page.waitForChanges();
+
+    // The state is persisted under the custom key, not the default one
+    expect(localStorage.getItem("CUSTOM_SIDEBAR_KEY")).toBe("true");
+    expect(
+      localStorage.getItem("SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE")
+    ).toBeNull();
   });
 
   it("hides content header and applies hide content header class when hideContentHeader is true", async () => {

--- a/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.stories.ts
+++ b/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.stories.ts
@@ -17,11 +17,38 @@ const Template = (args) => {
   const element = generateStoryElement("swirl-console-layout", args);
 
   element.innerHTML = `
-    <swirl-box padding="24" slot="navigation"><a href="#">Test</a></swirl-box>
-    <div slot="user">User</div>
+    <swirl-tree-navigation label="Main" slot="navigation">
+      <swirl-tree-navigation-item href="#home" icon="home" label="Home" navigation-item-id="home"></swirl-tree-navigation-item>
+      <swirl-tree-navigation-item icon="person" label="User management" navigation-item-id="user-management">
+        <swirl-tree-navigation-item active="true" href="#users" label="Users" navigation-item-id="users"></swirl-tree-navigation-item>
+        <swirl-tree-navigation-item href="#user-groups" label="User groups" navigation-item-id="user-groups"></swirl-tree-navigation-item>
+        <swirl-tree-navigation-item href="#user-attributes" label="User attributes" navigation-item-id="user-attributes"></swirl-tree-navigation-item>
+        <swirl-tree-navigation-item href="#post-on-behalf" label="Post on behalf" navigation-item-id="post-on-behalf"></swirl-tree-navigation-item>
+      </swirl-tree-navigation-item>
+      <swirl-tree-navigation-item href="#content" icon="description" label="Content" navigation-item-id="content"></swirl-tree-navigation-item>
+      <swirl-tree-navigation-item href="#analytics" icon="bar-chart" label="Analytics" navigation-item-id="analytics"></swirl-tree-navigation-item>
+      <swirl-tree-navigation-item href="#settings" icon="settings" label="Settings" navigation-item-id="settings"></swirl-tree-navigation-item>
+      <swirl-tree-navigation-item href="#access-security" icon="secure" label="Access &amp; security" navigation-item-id="access-security"></swirl-tree-navigation-item>
+      <swirl-tree-navigation-item href="#roadmap" icon="roadmap" label="Roadmap" navigation-item-id="roadmap"></swirl-tree-navigation-item>
+      <swirl-tree-navigation-item href="#excel-import" icon="upload" label="Excel import" navigation-item-id="excel-import"></swirl-tree-navigation-item>
+    </swirl-tree-navigation>
+    <div slot="user" style="display: flex; align-items: center; gap: 0.5rem; width: 100%; padding: 0.5rem; border-radius: 0.75rem;">
+      <swirl-avatar label="Catherine Carter" size="s"></swirl-avatar>
+      <swirl-text size="sm" weight="medium">Catherine Carter</swirl-text>
+    </div>
     <swirl-box center-block center-inline cover slot="content">Content</swirl-box>
-    <swirl-button intent="primary" label="Button" slot="content-header-tools" variant="flat"></swirl-button>
+    <swirl-button intent="primary" label="Add user" slot="content-header-tools" variant="flat"></swirl-button>
   `;
+
+  // Expand the "User management" item to match the design
+  customElements.whenDefined("swirl-tree-navigation-item").then(async () => {
+    const userManagementItem = element.querySelector(
+      '[navigation-item-id="user-management"]'
+    ) as HTMLSwirlTreeNavigationItemElement;
+
+    await userManagementItem?.componentOnReady();
+    await userManagementItem?.expand();
+  });
 
   return element;
 };
@@ -29,11 +56,9 @@ const Template = (args) => {
 export const SwirlConsoleLayout = Template.bind({});
 
 SwirlConsoleLayout.args = {
-  appName: "App name",
-  heading: "Heading",
-  showBackButton: true,
-  showHelpButton: true,
-  subheading: "Subheading",
+  heading: "Users",
+  logoText: "Admin Console",
+  maxContentWidth: "1200px",
 };
 
 const TemplateWithBothSlots = (args) => {

--- a/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.tsx
+++ b/packages/swirl-components/src/components/swirl-console-layout/swirl-console-layout.tsx
@@ -19,6 +19,7 @@ import { debounce, isMobileViewport } from "../../utils";
  * @slot content-header-tools - Button positioned next to the heading
  * @slot footer - Footer content positioned at the bottom of the layout
  * @slot heading - The main content's heading (only rendered if "heading" prop is not set).
+ * @slot logo - Custom logo (forwarded to the sidebar navigation)
  * @slot navigation - The main navigation
  * @slot overlays - Overlays like dialogs, modals and toasts
  * @slot user - The signed in user information at the bottom of the sidebar
@@ -42,6 +43,8 @@ export class SwirlConsoleLayout {
   @Prop() showBackButton?: boolean;
   @Prop() showHelpButton?: boolean;
   @Prop() showNavigationButtonLabel?: string = "Show main navigation";
+  @Prop() sidebarVisibilityStateStorageKey?: string =
+    "SWIRL_CONSOLE_LAYOUT_SIDEBAR_STATE";
   @Prop() subheading?: string;
   @Prop() hideContentHeader?: boolean;
 
@@ -52,19 +55,32 @@ export class SwirlConsoleLayout {
     scrolledToBottom: false,
   };
   @State() hasCustomAppBar: boolean;
+  @State() hasCustomLogo: boolean;
   @State() hasFooter: boolean;
   @Event() backButtonClick: EventEmitter<MouseEvent>;
   @Event() helpButtonClick: EventEmitter<MouseEvent>;
+  @Event() sidebarVisibilityChange: EventEmitter<boolean>;
 
-  private sidebarEl: HTMLElement;
   private contentEl: HTMLElement;
+  private pendingFocus?: "collapse-button" | "toggle";
+  private sidebarEl: HTMLElement;
+
+  componentWillLoad() {
+    // Seed the initial state before the first render to avoid a visible
+    // collapse/expand transition on load
+    if (typeof window !== "undefined" && Boolean(window.matchMedia)) {
+      this.sidebarActive = !isMobileViewport() && this.getStoredSidebarState();
+    }
+  }
 
   componentDidLoad() {
     queueMicrotask(() => {
-      if (!isMobileViewport()) {
-        this.activateSidebar();
+      // Sync the inert attribute with the initial state seeded in
+      // componentWillLoad, without emitting sidebarVisibilityChange
+      if (this.sidebarActive) {
+        this.sidebarEl?.removeAttribute("inert");
       } else {
-        this.deactivateSidebar();
+        this.sidebarEl?.setAttribute("inert", "");
       }
 
       // Update initial scroll state
@@ -72,12 +88,19 @@ export class SwirlConsoleLayout {
 
       // Update initial slot states
       this.updateCustomAppBarStatus();
+      this.updateCustomLogoStatus();
       this.updateFooterStatus();
     });
   }
 
   private updateCustomAppBarStatus = () => {
     this.hasCustomAppBar = Boolean(this.el.querySelector('[slot="app-bar"]'));
+  };
+
+  private updateCustomLogoStatus = () => {
+    // The forwarding slot is only rendered when a logo is actually slotted;
+    // otherwise it would suppress the sidebar navigation's logo fallback
+    this.hasCustomLogo = Boolean(this.el.querySelector('[slot="logo"]'));
   };
 
   private updateFooterStatus = () => {
@@ -114,15 +137,17 @@ export class SwirlConsoleLayout {
   onWindowResize() {
     const mobileViewport = isMobileViewport();
 
-    if (!mobileViewport && !this.sidebarActive) {
-      this.activateSidebar();
-    } else if (mobileViewport) {
-      this.deactivateSidebar();
+    if (mobileViewport) {
+      if (this.sidebarActive) {
+        this.deactivateSidebar(false);
+      }
+    } else if (this.getStoredSidebarState() !== this.sidebarActive) {
+      this.restoreSidebarState();
     }
   }
 
   /**
-   * Toggle the mobile navigation visibility.
+   * Toggle the sidebar visibility.
    */
   @Method()
   async toggleSidebar() {
@@ -134,7 +159,7 @@ export class SwirlConsoleLayout {
   }
 
   /**
-   * Show the mobile navigation.
+   * Show the sidebar.
    */
   @Method()
   async showSidebar() {
@@ -144,7 +169,7 @@ export class SwirlConsoleLayout {
   }
 
   /**
-   * Hide the mobile navigation.
+   * Hide the sidebar.
    */
   @Method()
   async hideSidebar() {
@@ -153,21 +178,99 @@ export class SwirlConsoleLayout {
     }
   }
 
-  private activateSidebar() {
-    this.sidebarActive = true;
-    this.sidebarEl.removeAttribute("inert");
-
-    if (isMobileViewport()) {
-      this.el.querySelector("swirl-tree-navigation-item")?.focus();
+  private restoreSidebarState() {
+    if (this.getStoredSidebarState()) {
+      this.activateSidebar(false);
+    } else {
+      this.deactivateSidebar(false);
     }
   }
 
-  private deactivateSidebar() {
-    this.sidebarActive = false;
+  private getStoredSidebarState(): boolean {
+    try {
+      return (
+        localStorage.getItem(this.sidebarVisibilityStateStorageKey) !== "false"
+      );
+    } catch {
+      return true;
+    }
+  }
+
+  private storeSidebarState(active: boolean) {
+    try {
+      localStorage.setItem(
+        this.sidebarVisibilityStateStorageKey,
+        String(active)
+      );
+    } catch {
+      // localStorage is unavailable; state is not persisted
+    }
+  }
+
+  private activateSidebar(moveFocus: boolean = true) {
+    this.sidebarActive = true;
+    this.sidebarEl?.removeAttribute("inert");
 
     if (isMobileViewport()) {
-      this.sidebarEl.setAttribute("inert", "");
+      if (moveFocus) {
+        this.el.querySelector("swirl-tree-navigation-item")?.focus();
+      }
+    } else {
+      this.storeSidebarState(true);
+
+      if (moveFocus) {
+        this.pendingFocus = "collapse-button";
+      }
     }
+
+    this.sidebarVisibilityChange.emit(true);
+  }
+
+  private deactivateSidebar(moveFocus: boolean = true) {
+    this.sidebarActive = false;
+    this.sidebarEl?.setAttribute("inert", "");
+
+    if (!isMobileViewport()) {
+      this.storeSidebarState(false);
+    }
+
+    if (moveFocus) {
+      this.pendingFocus = "toggle";
+    }
+
+    this.sidebarVisibilityChange.emit(false);
+  }
+
+  componentDidUpdate() {
+    // Focus moves must happen after the re-render is committed: the toggle
+    // buttons mount/unmount and the sidebar's visibility changes with the
+    // sidebar state, so focusing earlier is dropped by the browser
+    if (this.pendingFocus === "toggle") {
+      this.focusSidebarToggle();
+    } else if (this.pendingFocus === "collapse-button") {
+      (
+        this.sidebarEl as HTMLSwirlSidebarNavigationElement
+      )?.focusCollapseButton?.();
+    }
+
+    this.pendingFocus = undefined;
+  }
+
+  /**
+   * Move focus to the visible sidebar toggle after the sidebar was hidden,
+   * so keyboard users don't lose their place
+   */
+  private focusSidebarToggle() {
+    const candidates = [
+      this.el.shadowRoot.querySelector<HTMLElement>(
+        ".console-layout__show-sidebar-button"
+      ),
+      this.el.shadowRoot.querySelector<HTMLElement>(
+        ".console-layout__mobile-navigation-button button"
+      ),
+    ];
+
+    candidates.find((el) => Boolean(el) && el.offsetWidth > 0)?.focus();
   }
 
   private onBackButtonClick = (event: MouseEvent) => {
@@ -182,7 +285,19 @@ export class SwirlConsoleLayout {
     this.toggleSidebar();
   };
 
+  private onSidebarCollapseButtonClick = () => {
+    this.hideSidebar();
+  };
+
+  private onShowSidebarButtonClick = () => {
+    this.showSidebar();
+  };
+
   private onClick = (event: MouseEvent) => {
+    if (!isMobileViewport()) {
+      return;
+    }
+
     const target = event.target as HTMLElement;
 
     const clickOnToggle = Boolean(
@@ -203,6 +318,10 @@ export class SwirlConsoleLayout {
   };
 
   private onKeyDown = (event: KeyboardEvent) => {
+    if (!isMobileViewport()) {
+      return;
+    }
+
     if (event.code === "Escape" && this.sidebarActive) {
       this.deactivateSidebar();
     }
@@ -218,10 +337,12 @@ export class SwirlConsoleLayout {
       : undefined;
 
     this.updateCustomAppBarStatus();
+    this.updateCustomLogoStatus();
     this.updateFooterStatus();
 
     const className = classnames("console-layout", {
       "console-layout--sidebar-active": this.sidebarActive,
+      "console-layout--sidebar-hidden": !this.sidebarActive,
       "console-layout--empty-app-bar":
         !Boolean(this.appName) && !this.showHelpButton && !this.hasCustomAppBar,
       "console-layout--has-footer": this.hasFooter,
@@ -241,47 +362,38 @@ export class SwirlConsoleLayout {
           onClick={this.onClick}
           onKeyDown={this.onKeyDown}
         >
-          <header
+          <swirl-sidebar-navigation
+            appName={this.logoText}
             aria-hidden={String(!this.sidebarActive)}
             class="console-layout__sidebar"
+            collapseButtonLabel={this.hideNavigationButtonLabel}
+            id="sidebar"
+            navigationLabel={this.navigationLabel}
+            onCollapseButtonClick={this.onSidebarCollapseButtonClick}
             ref={(el) => (this.sidebarEl = el)}
           >
-            <div class="console-layout__header">
-              <div class="console-layout__logo">
-                <svg
-                  class="console-layout__logo-mark"
-                  fill="none"
-                  height="26"
-                  viewBox="0 0 301 460"
-                  width="16"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    fill-rule="evenodd"
-                    clip-rule="evenodd"
-                    d="M2.52486 276.36C5.57709 289.149 11.02 301.094 18.2296 311.628L258.719 138.748C269.874 131.507 278.35 121.993 285.395 110.766C291.904 100.212 296.922 87.3014 298.875 74.6738C300.769 61.4277 300.809 48.353 297.757 35.5639C294.705 22.7748 289.262 10.8302 282.052 0.296051L41.5626 173.176C30.4077 180.417 21.9314 189.931 14.8867 201.158C8.37746 211.712 3.35926 224.623 1.40724 237.25C-0.544773 249.878 0.0338964 262.896 2.52486 276.36ZM80.3121 424.184C83.3644 436.973 88.8073 448.918 96.0169 459.452L229.113 363.743C240.268 356.502 248.744 346.988 255.789 335.761C262.298 325.207 267.317 312.296 269.269 299.668C271.164 286.422 271.203 273.348 268.151 260.559C265.099 247.769 259.656 235.825 252.446 225.291L119.35 320.999C108.195 328.24 99.7187 337.755 92.674 348.982C86.1647 359.535 81.1465 372.446 79.1945 385.074C77.2996 398.32 77.2599 411.395 80.3121 424.184Z"
-                    fill="#2151F5"
-                  />
-                </svg>
-                <swirl-text class="console-layout__logo-text" weight="medium">
-                  {this.logoText}
-                </swirl-text>
-              </div>
-            </div>
-            <nav
-              aria-label={this.navigationLabel}
-              class="console-layout__navigation"
-            >
-              <slot name="navigation"></slot>
-            </nav>
-            <div class="console-layout__user">
-              <slot name="user"></slot>
-            </div>
-          </header>
+            {this.hasCustomLogo && <slot name="logo" slot="logo"></slot>}
+            <slot name="navigation"></slot>
+            <slot name="user" slot="user"></slot>
+          </swirl-sidebar-navigation>
           <main
             aria-labelledby={Boolean(this.appName) ? "app-name" : undefined}
             class="console-layout__main"
           >
+            {!this.sidebarActive && (
+              <button
+                aria-controls="sidebar"
+                aria-expanded="false"
+                aria-label={this.showNavigationButtonLabel}
+                class="console-layout__show-sidebar-button"
+                onClick={this.onShowSidebarButtonClick}
+                type="button"
+              >
+                <swirl-icon-hamburger-menu
+                  size={20}
+                ></swirl-icon-hamburger-menu>
+              </button>
+            )}
             <header class="console-layout__app-bar console-layout__app-bar--custom">
               <slot
                 name="app-bar"

--- a/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.css
+++ b/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.css
@@ -1,0 +1,131 @@
+:host {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.sidebar-navigation {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  background: var(
+    --swirl-sidebar-navigation-background,
+    var(--s-translucent-low-default)
+  );
+  backdrop-filter: blur(var(--s-blur-l));
+  -webkit-backdrop-filter: blur(var(--s-blur-l));
+  border-radius: var(
+    --swirl-sidebar-navigation-border-radius,
+    var(--s-border-radius-l)
+  );
+  overflow: hidden;
+
+  & * {
+    box-sizing: border-box;
+  }
+}
+
+.sidebar-navigation--elevated {
+  box-shadow: var(--s-shadow-level-2);
+}
+
+.sidebar-navigation__header {
+  display: flex;
+  min-height: 4.5rem; /* 56px row + 2×8px padding */
+  padding: var(--s-space-8);
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+  /* Transparent by default; reveals a divider once the nav scrolls so the
+     scrolling content does not bleed flush against the header */
+  border-bottom: var(--s-border-width-default) solid transparent;
+  gap: var(--s-space-8);
+}
+
+.sidebar-navigation--scrollable:not(.sidebar-navigation--scrolled-to-top)
+  .sidebar-navigation__header {
+  border-bottom-color: var(--s-border-default);
+}
+
+.sidebar-navigation__logo-section {
+  display: flex;
+  min-width: 0;
+  height: 3.5rem;
+  padding-left: var(--s-space-8);
+  align-items: center;
+  gap: var(--s-space-16);
+  flex-grow: 1;
+}
+
+.sidebar-navigation__logo,
+::slotted([slot="logo"]) {
+  flex-shrink: 0;
+}
+
+.sidebar-navigation__app-name {
+  overflow: hidden;
+  color: var(--s-text-default);
+  font-family: var(
+    --swirl-sidebar-navigation-app-name-font-family,
+    "Clash Grotesk Variable",
+    var(--s-font-family-text)
+  );
+  font-size: var(--swirl-sidebar-navigation-app-name-font-size, 1.5rem);
+  font-style: normal;
+  font-weight: var(--s-font-weight-medium);
+  line-height: var(--s-line-height-sm);
+  letter-spacing: var(--s-letter-spacing-normal);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.sidebar-navigation__collapse-button {
+  display: flex;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: var(--s-space-8);
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border: none;
+  border-radius: var(--s-border-radius-full-round);
+  background-color: var(--s-surface-raised-50-default);
+  color: var(--s-icon-strong);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--s-surface-raised-50-hovered);
+  }
+
+  &:active {
+    background-color: var(--s-surface-raised-50-pressed);
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    box-shadow: 0 0 0 0.125rem var(--s-focus-default);
+  }
+}
+
+.sidebar-navigation__content {
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0 var(--s-space-8);
+  flex: 1 1 auto;
+}
+
+.sidebar-navigation__footer {
+  padding: var(--s-space-8);
+  flex-shrink: 0;
+  /* Transparent by default; reveals a divider while more nav content remains
+     below the fold so the scrolling content does not bleed into the footer */
+  border-top: var(--s-border-width-default) solid transparent;
+}
+
+.sidebar-navigation--scrollable:not(.sidebar-navigation--scrolled-to-bottom)
+  .sidebar-navigation__footer {
+  border-top-color: var(--s-border-default);
+}

--- a/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.mdx
+++ b/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.mdx
@@ -1,0 +1,53 @@
+import { Canvas, Controls, Meta, Source } from "@storybook/addon-docs/blocks";
+import * as Stories from "./swirl-sidebar-navigation.stories";
+
+<Meta title="Components/SwirlSidebarNavigation" />
+
+# SwirlSidebarNavigation
+
+The SwirlSidebarNavigation component is a reusable sidebar navigation shell
+consisting of a header with a logo and a collapse trigger, a scrollable
+navigation area, and a user footer. It is used by SwirlConsoleLayout and can be
+used standalone in apps.
+
+- **[Figma Design Specs](#)**
+- **[Source Code](https://github.com/flip-corp/swirl/tree/main/packages/swirl-components/src/components/swirl-sidebar-navigation)**
+
+## Usage
+
+Please use the
+[canvas view](?path=/story/components-swirlsidebarnavigation--swirl-sidebar-navigation)
+to preview this component.
+
+Place a custom logo in the `logo` slot (falls back to a 32×32 rounded tile
+showing the Flip logo mark), navigation content like SwirlTreeNavigation in the
+default slot, and user profile content in the `user` slot. The
+`collapseButtonClick` event is emitted when the collapse button is activated;
+the host app or parent layout decides what to do with it. Set `elevated` to add
+a drop shadow for floating/overlay use.
+
+Use the `focusCollapseButton` method to programmatically move focus to the
+collapse button. Parent layouts like SwirlConsoleLayout use it to keep keyboard
+focus in place after the sidebar is expanded.
+
+<Controls of={Stories.SwirlSidebarNavigation} />
+
+## Related components
+
+[SwirlConsoleLayout](?path=/docs/admin-swirlconsolelayout--docs),
+[SwirlTreeNavigation](?path=/docs/admin-swirltreenavigation--docs)
+
+## Accessibility
+
+The navigation area is rendered as a `<nav>` element labeled via the
+`navigationLabel` prop. The collapse button is a native `<button>` with
+`aria-expanded="true"` and an accessible label provided by the
+`collapseButtonLabel` prop. The fallback logo is decorative and hidden from
+assistive technology via `aria-hidden`.
+
+### Keyboard
+
+| Key              | Action                         |
+| ---------------- | ------------------------------ |
+| <kbd>ENTER</kbd> | Activates the collapse button. |
+| <kbd>SPACE</kbd> | Activates the collapse button. |

--- a/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.spec.tsx
@@ -1,0 +1,93 @@
+import { newSpecPage } from "@stencil/core/testing";
+
+import { SwirlSidebarNavigation } from "./swirl-sidebar-navigation";
+
+describe("swirl-sidebar-navigation", () => {
+  it("renders its slots, app name, and logo fallback", async () => {
+    const page = await newSpecPage({
+      components: [SwirlSidebarNavigation],
+      html: `
+        <swirl-sidebar-navigation app-name="Fusion">
+          <div>Navigation</div>
+          <div slot="user">User</div>
+        </swirl-sidebar-navigation>
+      `,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <swirl-sidebar-navigation app-name="Fusion">
+        <mock:shadow-root>
+          <div class="sidebar-navigation">
+            <header class="sidebar-navigation__header">
+              <div class="sidebar-navigation__logo-section">
+                <slot name="logo">
+                  <svg aria-hidden="true" class="sidebar-navigation__logo" fill="none" height="32" viewBox="0 0 32 32" width="32" xmlns="http://www.w3.org/2000/svg">
+                    <rect fill="#2151F5" height="32" rx="8" width="32"></rect>
+                    <path clip-rule="evenodd" d="M2.52486 276.36C5.57709 289.149 11.02 301.094 18.2296 311.628L258.719 138.748C269.874 131.507 278.35 121.993 285.395 110.766C291.904 100.212 296.922 87.3014 298.875 74.6738C300.769 61.4277 300.809 48.353 297.757 35.5639C294.705 22.7748 289.262 10.8302 282.052 0.296051L41.5626 173.176C30.4077 180.417 21.9314 189.931 14.8867 201.158C8.37746 211.712 3.35926 224.623 1.40724 237.25C-0.544773 249.878 0.0338964 262.896 2.52486 276.36ZM80.3121 424.184C83.3644 436.973 88.8073 448.918 96.0169 459.452L229.113 363.743C240.268 356.502 248.744 346.988 255.789 335.761C262.298 325.207 267.317 312.296 269.269 299.668C271.164 286.422 271.203 273.348 268.151 260.559C265.099 247.769 259.656 235.825 252.446 225.291L119.35 320.999C108.195 328.24 99.7187 337.755 92.674 348.982C86.1647 359.535 81.1465 372.446 79.1945 385.074C77.2996 398.32 77.2599 411.395 80.3121 424.184Z" fill="#FFFFFF" fill-rule="evenodd" transform="translate(9.7 6.4) scale(0.0418)"></path>
+                  </svg>
+                </slot>
+                <span class="sidebar-navigation__app-name">
+                  Fusion
+                </span>
+              </div>
+              <button aria-expanded="true" aria-label="Hide navigation" class="sidebar-navigation__collapse-button" type="button">
+                <swirl-icon-double-arrow-left size="24"></swirl-icon-double-arrow-left>
+              </button>
+            </header>
+            <nav aria-label="Main" class="sidebar-navigation__content">
+              <slot></slot>
+            </nav>
+            <div class="sidebar-navigation__footer">
+              <slot name="user"></slot>
+            </div>
+          </div>
+        </mock:shadow-root>
+        <div>
+          Navigation
+        </div>
+        <div slot="user">
+          User
+        </div>
+      </swirl-sidebar-navigation>
+    `);
+  });
+
+  it("emits collapseButtonClick when the collapse button is clicked", async () => {
+    const page = await newSpecPage({
+      components: [SwirlSidebarNavigation],
+      html: `<swirl-sidebar-navigation></swirl-sidebar-navigation>`,
+    });
+
+    const spy = jest.fn();
+
+    page.root.addEventListener("collapseButtonClick", spy);
+
+    page.root.shadowRoot
+      .querySelector<HTMLButtonElement>(".sidebar-navigation__collapse-button")
+      .click();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("hides the collapse button", async () => {
+    const page = await newSpecPage({
+      components: [SwirlSidebarNavigation],
+      html: `<swirl-sidebar-navigation hide-collapse-button></swirl-sidebar-navigation>`,
+    });
+
+    expect(
+      page.root.shadowRoot.querySelector(".sidebar-navigation__collapse-button")
+    ).toBeNull();
+  });
+
+  it("applies the elevated modifier", async () => {
+    const page = await newSpecPage({
+      components: [SwirlSidebarNavigation],
+      html: `<swirl-sidebar-navigation elevated></swirl-sidebar-navigation>`,
+    });
+
+    expect(
+      page.root.shadowRoot.querySelector(".sidebar-navigation")
+    ).toHaveClass("sidebar-navigation--elevated");
+  });
+});

--- a/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.stories.ts
+++ b/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.stories.ts
@@ -1,0 +1,67 @@
+import { generateStoryElement } from "../../utils";
+import Docs from "./swirl-sidebar-navigation.mdx";
+
+export default {
+  component: "swirl-sidebar-navigation",
+  decorators: [
+    (story) => {
+      const container = document.createElement("div");
+      const sidebarContainer = document.createElement("div");
+
+      container.style.background =
+        "linear-gradient(162deg, #e8f1ff 10.92%, #d9e5ff 84.6%)";
+      container.style.boxSizing = "border-box";
+      container.style.height = "100vh";
+      container.style.padding = "0.5rem";
+
+      sidebarContainer.style.height = "100%";
+      sidebarContainer.style.width = "296px";
+
+      sidebarContainer.appendChild(story());
+      container.appendChild(sidebarContainer);
+
+      return container;
+    },
+  ],
+  parameters: {
+    docs: {
+      page: Docs,
+    },
+    layout: "fullscreen",
+  },
+  title: "Components/SwirlSidebarNavigation",
+};
+
+const Template = (args) => {
+  const element = generateStoryElement("swirl-sidebar-navigation", args);
+
+  element.innerHTML = `
+    <swirl-tree-navigation label="Main">
+      <swirl-tree-navigation-item href="#home" icon="home" label="Home" navigation-item-id="home"></swirl-tree-navigation-item>
+      <swirl-tree-navigation-item icon="person" label="User management" navigation-item-id="user-management">
+        <swirl-tree-navigation-item active="true" href="#users" label="Users" navigation-item-id="users"></swirl-tree-navigation-item>
+        <swirl-tree-navigation-item href="#user-groups" label="User groups" navigation-item-id="user-groups"></swirl-tree-navigation-item>
+      </swirl-tree-navigation-item>
+      <swirl-tree-navigation-item href="#settings" icon="settings" label="Settings" navigation-item-id="settings"></swirl-tree-navigation-item>
+    </swirl-tree-navigation>
+    <div slot="user" style="display: flex; align-items: center; gap: 0.5rem; width: 100%; padding: 0.5rem; border-radius: 0.75rem;">
+      <swirl-avatar label="Catherine Carter" size="s"></swirl-avatar>
+      <swirl-text size="sm" weight="medium">Catherine Carter</swirl-text>
+    </div>
+  `;
+
+  return element;
+};
+
+export const SwirlSidebarNavigation = Template.bind({});
+
+SwirlSidebarNavigation.args = {
+  appName: "Fusion",
+};
+
+export const Elevated = Template.bind({});
+
+Elevated.args = {
+  appName: "Fusion",
+  elevated: true,
+};

--- a/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.tsx
+++ b/packages/swirl-components/src/components/swirl-sidebar-navigation/swirl-sidebar-navigation.tsx
@@ -1,0 +1,168 @@
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Method,
+  Prop,
+  State,
+} from "@stencil/core";
+import classnames from "classnames";
+import { debounce } from "../../utils";
+
+/**
+ * @slot logo - Custom logo/brand mark shown in the header (32×32). Falls back to the Flip logo mark.
+ * @slot (default) - Navigation content (e.g. swirl-tree-navigation)
+ * @slot user - User profile content pinned to the bottom
+ */
+@Component({
+  shadow: true,
+  styleUrl: "swirl-sidebar-navigation.css",
+  tag: "swirl-sidebar-navigation",
+})
+export class SwirlSidebarNavigation {
+  @Element() el: HTMLElement;
+
+  @Prop() appName?: string;
+  @Prop() collapseButtonLabel?: string = "Hide navigation";
+  @Prop() elevated?: boolean;
+  @Prop() hideCollapseButton?: boolean;
+  @Prop() navigationLabel?: string = "Main";
+
+  @Event() collapseButtonClick: EventEmitter<MouseEvent>;
+
+  @State() contentScrollState = {
+    scrollable: false,
+    scrolledToTop: true,
+    scrolledToBottom: true,
+  };
+
+  private contentEl: HTMLElement;
+
+  componentDidLoad() {
+    this.updateContentScrollState();
+  }
+
+  /**
+   * Focus the collapse button.
+   */
+  @Method()
+  async focusCollapseButton() {
+    this.el.shadowRoot
+      .querySelector<HTMLButtonElement>(".sidebar-navigation__collapse-button")
+      ?.focus();
+  }
+
+  @Listen("resize", { target: "window" })
+  onWindowResize() {
+    this.updateContentScrollState();
+  }
+
+  private updateContentScrollState() {
+    if (!this.contentEl) {
+      return;
+    }
+
+    const newContentScrollState = {
+      scrollable: this.contentEl.scrollHeight > this.contentEl.clientHeight,
+      scrolledToTop: this.contentEl.scrollTop === 0,
+      scrolledToBottom:
+        Math.round(this.contentEl.scrollTop + this.contentEl.clientHeight) >=
+        this.contentEl.scrollHeight,
+    };
+
+    if (
+      Object.keys(newContentScrollState).some(
+        (key) => newContentScrollState[key] !== this.contentScrollState[key]
+      )
+    ) {
+      this.contentScrollState = newContentScrollState;
+    }
+  }
+
+  private onContentScroll = debounce(() => {
+    this.updateContentScrollState();
+  }, 16);
+
+  private onNavigationSlotChange = () => {
+    // Items can be added/removed after slotted children hydrate; defer the
+    // measurement until the next frame so layout has settled
+    requestAnimationFrame(() => this.updateContentScrollState());
+  };
+
+  private onCollapseButtonClick = (event: MouseEvent) => {
+    this.collapseButtonClick.emit(event);
+  };
+
+  render() {
+    const className = classnames("sidebar-navigation", {
+      "sidebar-navigation--elevated": this.elevated,
+      "sidebar-navigation--scrollable": this.contentScrollState.scrollable,
+      "sidebar-navigation--scrolled-to-top":
+        this.contentScrollState.scrolledToTop,
+      "sidebar-navigation--scrolled-to-bottom":
+        this.contentScrollState.scrolledToBottom,
+    });
+
+    return (
+      <Host>
+        <div class={className}>
+          <header class="sidebar-navigation__header">
+            <div class="sidebar-navigation__logo-section">
+              <slot name="logo">
+                <svg
+                  aria-hidden="true"
+                  class="sidebar-navigation__logo"
+                  fill="none"
+                  height="32"
+                  viewBox="0 0 32 32"
+                  width="32"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <rect fill="#2151F5" height="32" rx="8" width="32" />
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M2.52486 276.36C5.57709 289.149 11.02 301.094 18.2296 311.628L258.719 138.748C269.874 131.507 278.35 121.993 285.395 110.766C291.904 100.212 296.922 87.3014 298.875 74.6738C300.769 61.4277 300.809 48.353 297.757 35.5639C294.705 22.7748 289.262 10.8302 282.052 0.296051L41.5626 173.176C30.4077 180.417 21.9314 189.931 14.8867 201.158C8.37746 211.712 3.35926 224.623 1.40724 237.25C-0.544773 249.878 0.0338964 262.896 2.52486 276.36ZM80.3121 424.184C83.3644 436.973 88.8073 448.918 96.0169 459.452L229.113 363.743C240.268 356.502 248.744 346.988 255.789 335.761C262.298 325.207 267.317 312.296 269.269 299.668C271.164 286.422 271.203 273.348 268.151 260.559C265.099 247.769 259.656 235.825 252.446 225.291L119.35 320.999C108.195 328.24 99.7187 337.755 92.674 348.982C86.1647 359.535 81.1465 372.446 79.1945 385.074C77.2996 398.32 77.2599 411.395 80.3121 424.184Z"
+                    fill="#FFFFFF"
+                    transform="translate(9.7 6.4) scale(0.0418)"
+                  />
+                </svg>
+              </slot>
+              {Boolean(this.appName) && (
+                <span class="sidebar-navigation__app-name">{this.appName}</span>
+              )}
+            </div>
+            {!this.hideCollapseButton && (
+              <button
+                aria-expanded="true"
+                aria-label={this.collapseButtonLabel}
+                class="sidebar-navigation__collapse-button"
+                onClick={this.onCollapseButtonClick}
+                type="button"
+              >
+                <swirl-icon-double-arrow-left
+                  size={24}
+                ></swirl-icon-double-arrow-left>
+              </button>
+            )}
+          </header>
+          <nav
+            aria-label={this.navigationLabel}
+            class="sidebar-navigation__content"
+            onScroll={this.onContentScroll}
+            ref={(el) => (this.contentEl = el)}
+          >
+            <slot onSlotchange={this.onNavigationSlotChange}></slot>
+          </nav>
+          <div class="sidebar-navigation__footer">
+            <slot name="user"></slot>
+          </div>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/swirl-components/src/styles/global.css
+++ b/packages/swirl-components/src/styles/global.css
@@ -45,6 +45,13 @@
 
   --swirl-carousel-gradient: 255, 255, 255;
 
+  --swirl-console-layout-background: radial-gradient(
+      140% 78% at 50% 116%,
+      rgba(20, 90, 245, 0.46) 0%,
+      rgba(20, 90, 245, 0) 68%
+    ),
+    var(--s-surface-sunken-default);
+
   --swirl-icon-button-border-top-right-radius: 50%;
   --swirl-icon-button-border-top-left-radius: 50%;
   --swirl-icon-button-border-bottom-right-radius: 50%;
@@ -100,6 +107,7 @@
 
 html.theme-dark {
   --swirl-carousel-gradient: 25, 26, 28;
+  --swirl-console-layout-background: var(--s-surface-sunken-default);
   color-scheme: dark;
 }
 

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -2745,6 +2745,10 @@
           "description": ""
         },
         {
+          "name": "sidebar-visibility-state-storage-key",
+          "description": ""
+        },
+        {
           "name": "subheading",
           "description": ""
         }
@@ -22722,6 +22726,35 @@
         },
         {
           "name": "with-gradient",
+          "description": ""
+        }
+      ]
+    },
+    {
+      "name": "swirl-sidebar-navigation",
+      "description": {
+        "kind": "markdown",
+        "value": ""
+      },
+      "attributes": [
+        {
+          "name": "app-name",
+          "description": ""
+        },
+        {
+          "name": "collapse-button-label",
+          "description": ""
+        },
+        {
+          "name": "elevated",
+          "description": ""
+        },
+        {
+          "name": "hide-collapse-button",
+          "description": ""
+        },
+        {
+          "name": "navigation-label",
           "description": ""
         }
       ]


### PR DESCRIPTION
# Console layout: collapsible sidebar + new `swirl-sidebar-navigation`

Linear: [ACT-3612 — Update the Swirl console layout](https://linear.app/flip/issue/ACT-3612/update-the-swirl-console-layout)

> Draft — built design-first with Claude Code. Needs a dev pass against the Swirl PR checklist (a11y/SR, dark theme, design parity) before merge. Open questions at the bottom.

## What this does
Adds a hideable/collapsible navigation to `swirl-console-layout` (expanded ↔ hidden) and extracts the sidebar chrome into a new reusable **`swirl-sidebar-navigation`** component, so it can be reused in other apps.

### New component: `swirl-sidebar-navigation`
A 296px sidebar shell:
- `logo` slot (falls back to the Flip mark), `appName` wordmark
- Collapse button → emits `collapseButtonClick` (host decides behavior)
- Scrollable default slot for nav content, with **scroll-state dividers** on the header/footer that appear only while content is scrolled (mirrors the `swirl-console-layout` app-bar pattern)
- `user` footer slot
- `elevated` shadow variant; `focusCollapseButton()` method

### `swirl-console-layout` (backward-compatible — additions only)
- Renders the sidebar through `swirl-sidebar-navigation`
- Desktop sidebar can be **hidden** (collapse button) and **reopened** (floating translucent button, or the app-bar toggle when an app bar is shown); state persists to `localStorage`
- New: `sidebarVisibilityChange` event, `logo` slot, `sidebarVisibilityStateStorageKey` prop
- New shell styling per *Web Components 2.0*: ambient radial-glow background on a sunken surface (themeable via `--swirl-console-layout-background`), rounded content card, translucent 296px sidebar
- Focus is moved to the visible toggle on hide/show (keyboard users don't lose their place)
- Fixed a grid `min-height` overflow so the layout fills its container and scrolls internally instead of growing to content height

**Behavior change to flag:** `toggleSidebar()`/`showSidebar()`/`hideSidebar()` now affect desktop too (previously mobile-only). If a consumer calls `hideSidebar()` on route change to close the mobile drawer, it should guard with a viewport check. The mobile drawer is now full-height and overlays the app bar.

## Design
Figma — *Web Components 2.0*: [console layout / background](https://www.figma.com/design/aIsxMzrP5myDMpvxaRIHXB/Web-Components-2.0?node-id=2603-3514), [sidebar nav](https://www.figma.com/design/aIsxMzrP5myDMpvxaRIHXB/Web-Components-2.0?node-id=2574-671). Expanded/hidden states from *Flip Fusion*: [expanded](https://www.figma.com/design/8RgkD8tm01Ob5NDDeBOKJb/Flip-Fusion?node-id=1997-57840), [hidden](https://www.figma.com/design/8RgkD8tm01Ob5NDDeBOKJb/Flip-Fusion?node-id=1997-58474).

## Verification
- `yarn test` — full suite green (505+ tests); the two touched components: 22/22
- `yarn lint` clean; prettier clean
- Manually checked in Storybook (light theme): expanded/hidden toggle, localStorage persistence across reload, mobile drawer (open/Escape/outside-click/collapse), focus move on hide/show, 296px width, scroll-state dividers, and short-viewport (no overflow / internal scroll)

## Preview
- **Hosted:** this PR auto-deploys Storybook to Azure SWA (a preview URL is posted as a PR comment by the deploy workflow). Stories: `Admin / SwirlConsoleLayout` and `Components / SwirlSidebarNavigation`.
- **Local:** `cd packages/swirl-components && yarn stencil:build && yarn storybook:start` → http://localhost:6006

## Open questions for review
1. **Clash Grotesk** — the `appName` uses `"Clash Grotesk Variable"` per design, but the font isn't bundled in Swirl; it falls back to Inter unless the host app loads it. Should we add an `@font-face`, or leave it to consumers?
2. **Sidebar width** — `swirl-sidebar-navigation` stays `width: 100%` (fills its container; the 296px is set by `swirl-console-layout` and the story). Prefer a hardcoded 296px default on the component instead?
3. **Mobile drawer** — closes on outside-click but isn't fully modal (no backdrop, background stays tabbable). Make it properly modal (inert + focus trap), or keep as-is (matches prior behavior)?
4. **`:host { height: 100vh }`** — unchanged from the original; if the layout is ever embedded in a sized parent rather than the viewport, this may want to be `100%`.
5. **Dark theme** — the shell background has a safe solid `surface-sunken` dark default (no dark design was provided); confirm or supply the dark spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
