### PR TITLE
chore: prevent text selection when double clicking swirl-text-input stepper arrows

### DIFF
--- a/.changeset/tricky-penguins-suffer.md
+++ b/.changeset/tricky-penguins-suffer.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Prevent text selection when double clicking swirl-text-input stepper arrows

--- a/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.css
+++ b/packages/swirl-components/src/components/swirl-text-input/swirl-text-input.css
@@ -189,6 +189,8 @@
   color: var(--s-icon-default);
   background-color: transparent;
   cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
 
   &:focus:not(:focus-visible) {
     outline: none;
@@ -209,6 +211,8 @@
   right: 0;
   display: flex;
   flex-direction: column;
+  -webkit-user-select: none;
+  user-select: none;
 
   @media (--from-desktop-without-touch) {
     top: -1.25rem;
@@ -223,6 +227,8 @@
   color: var(--s-icon-default);
   background-color: transparent;
   cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
 
   &:focus:not(:focus-visible) {
     outline: none;


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/ACT-3716/swirl-prevent-text-selection-when-double-clicking-number-input-stepper)
- [Design](#)
- [Storybook](#)

### The problem

https://github.com/user-attachments/assets/57c81bbe-efb5-40d1-aa43-d80ff87694d6

### How it looks with this update

https://github.com/user-attachments/assets/8e29a742-ddf4-4fde-97ab-73259e9bf58a



