### PR TITLE
feat: improve toggle group background contrast

### DIFF
--- a/.changeset/fair-rules-juggle.md
+++ b/.changeset/fair-rules-juggle.md
@@ -1,5 +1,8 @@
 ---
 "@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+"@getflip/swirl-ai": patch
 ---
 
 Improve toggle filter contrast by removing the default SwirlToggleButton background and adding a raised surface background for the translucent SwirlToggleGroup variant.

--- a/.changeset/fair-rules-juggle.md
+++ b/.changeset/fair-rules-juggle.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Improve toggle filter contrast by removing the default SwirlToggleButton background and adding a raised surface background for the translucent SwirlToggleGroup variant.

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -63019,7 +63019,7 @@
             {
               "name": "variant",
               "type": {
-                "text": "\"flat\" | \"outline\"",
+                "text": "\"flat\" | \"outline\" | \"translucent\"",
                 "references": [
                   {
                     "name": "SwirlToggleGroupVariant"
@@ -63061,7 +63061,7 @@
               "kind": "field",
               "name": "variant",
               "type": {
-                "text": "\"flat\" | \"outline\"",
+                "text": "\"flat\" | \"outline\" | \"translucent\"",
                 "references": [
                   {
                     "name": "SwirlToggleGroupVariant"

--- a/packages/swirl-components/src/components/swirl-toggle-button/swirl-toggle-button.css
+++ b/packages/swirl-components/src/components/swirl-toggle-button/swirl-toggle-button.css
@@ -16,7 +16,7 @@
   border: none;
   border-radius: 0.375rem;
   color: var(--s-text-default);
-  background-color: var(--s-surface-sunken-default);
+  background-color: transparent;
   font: inherit;
   font-weight: var(--s-font-weight-medium);
   line-height: var(--s-line-height-lg);

--- a/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.css
+++ b/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.css
@@ -20,4 +20,8 @@
     outline: var(--s-border-width-default) solid var(--s-border-strong);
     outline-offset: calc(var(--s-border-width-default) * -1);
   }
+
+  &--variant-translucent {
+    background-color: transparent;
+  }
 }

--- a/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.css
+++ b/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.css
@@ -22,6 +22,6 @@
   }
 
   &--variant-translucent {
-    background-color: transparent;
+    background-color: var(--s-surface-raised-default);
   }
 }

--- a/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.tsx
+++ b/packages/swirl-components/src/components/swirl-toggle-group/swirl-toggle-group.tsx
@@ -10,7 +10,7 @@ import {
 } from "@stencil/core";
 import classnames from "classnames";
 
-export type SwirlToggleGroupVariant = "flat" | "outline";
+export type SwirlToggleGroupVariant = "flat" | "outline" | "translucent";
 
 @Component({
   shadow: true,

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -26564,6 +26564,9 @@
             },
             {
               "name": "outline"
+            },
+            {
+              "name": "translucent"
             }
           ]
         }

--- a/packages/swirl-tokens/dart/lib/styles.dark.dart
+++ b/packages/swirl-tokens/dart/lib/styles.dark.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Tue, 23 Jun 2026 02:29:03 GMT
+// Generated on Thu, 16 Jul 2026 07:28:31 GMT
 
 
 

--- a/packages/swirl-tokens/dart/lib/styles.light.dart
+++ b/packages/swirl-tokens/dart/lib/styles.light.dart
@@ -4,7 +4,7 @@
 //
 
 // Do not edit directly
-// Generated on Tue, 23 Jun 2026 02:29:03 GMT
+// Generated on Thu, 16 Jul 2026 07:28:31 GMT
 
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- [Design](https://www.figma.com/design/aIsxMzrP5myDMpvxaRIHXB/Web-Components-2.0?node-id=2735-5308&t=Oyzpmd2pp837qPUY-11)
- Storybook: Components/SwirlToggleButton and Components/SwirlToggleGroup

## Changes

This PR addresses the poor background contrast in the homepage filters by improving the toggle button and toggle group components.

### SwirlToggleButton
- Removed the default background color (now transparent)
- Maintained hover state with `--s-state-hovered` background
- Maintained pressed/active state with `--s-state-pressed` background

### SwirlToggleGroup
- Added new `translucent` variant with `--s-surface-raised-default` background

### Release note
- Added a patch changeset for `@getflip/swirl-components`, `@getflip/swirl-components-react`, `@getflip/swirl-components-angular`, and `@getflip/swirl-ai`

## Testing

All existing tests pass (105 test suites, 506 tests).

Visual testing in Storybook confirms:
- Toggle button displays transparent background in default state
- Hover state properly shows background color
- Pressed state properly shows background color
- Toggle group supports the new translucent variant with raised surface background

### Visual Examples

**Toggle Button - Default State**
[Toggle button default state](https://cursor.com/agents/bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoggle_button_default.webp)

**Toggle Button - Hover State**
[Toggle button hover state](https://cursor.com/agents/bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoggle_button_hover.webp)

**Toggle Button - Pressed State**
[Toggle button pressed state](https://cursor.com/agents/bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoggle_button_pressed.webp)

**Toggle Group - Default**
[Toggle group default](https://cursor.com/agents/bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoggle_group_default.webp)

**Toggle Group - Translucent Variant**
[Toggle group translucent variant](https://cursor.com/agents/bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoggle_group_translucent.webp)

**Toggle Group - Translucent Hover**
[Toggle group translucent hover](https://cursor.com/agents/bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoggle_group_translucent_hover.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [FLO-778](https://linear.app/flip/issue/FLO-778/improve-toggle-group-background-contrast)

<div><a href="https://cursor.com/agents/bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c2a3202-fe55-4b2d-9cf1-e2fdbd891c06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

