### PR TITLE
fix(swirl-button): use strong text/icon color tokens for intent=strong + variant=outline

### DIFF
--- a/.changeset/swirlbutton-outline-strong-colors.md
+++ b/.changeset/swirlbutton-outline-strong-colors.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix SwirlButton (intent=strong, variant=outline) icon and text rendering with the subdued/default gray tokens instead of the strong/default dark tokens

--- a/packages/swirl-components/src/components/swirl-button/swirl-button.css
+++ b/packages/swirl-components/src/components/swirl-button/swirl-button.css
@@ -201,6 +201,14 @@
     outline-color: var(--s-border-default);
   }
 
+  &.button--intent-strong:where(:not(:disabled):not(.button--disabled)) {
+    color: var(--s-text-default);
+
+    & .button__icon {
+      color: var(--s-icon-strong);
+    }
+  }
+
   &.button--intent-critical:where(:not(:disabled):not(.button--disabled)) {
     color: var(--s-text-critical);
     outline-color: var(--s-border-critical);


### PR DESCRIPTION
When a SwirlButton has intent=strong and variant=outline, the icon and label render with the subdued/default gray tokens instead of the intended strong/default dark tokens. The button looks muted rather than strong.
This pr will fix that.
Affected condition (only this combination): intent="strong" AND variant="outline"