### PR TITLE
fix: use critical text token for separator label in critical variant

### DIFF
--- a/.changeset/separator-critical-label-color.md
+++ b/.changeset/separator-critical-label-color.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix SwirlSeparator (color=critical) label rendering with the subdued text token instead of the critical text token

--- a/packages/swirl-components/src/components/swirl-separator/swirl-separator.css
+++ b/packages/swirl-components/src/components/swirl-separator/swirl-separator.css
@@ -26,7 +26,7 @@
     }
 
     & .separator__label {
-      color: var(--s-text-subdued);
+      color: var(--s-text-critical);
     }
   }
 


### PR DESCRIPTION
## Summary

- [Ticket](#)
- [Design](#) https://www.figma.com/design/aIsxMzrP5myDMpvxaRIHXB/Web-Components-2.0?node-id=2836-3538&t=oIwsBUzhgpWtLYQO-11
- [Storybook](#)
