### PR TITLE
Fix tree not updating on slot change

### DIFF
--- a/.changeset/clever-bananas-wait.md
+++ b/.changeset/clever-bananas-wait.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-ai": patch
+"@getflip/swirl-components": patch
+"@getflip/swirl-components-angular": patch
+"@getflip/swirl-components-react": patch
+---
+
+Trigger rerender when slotted children change in SwirlTreeViewItem

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.spec.tsx
@@ -91,4 +91,69 @@ describe("swirl-tree-view-item", () => {
 
     expect(page.root.querySelector('[aria-selected="true"]')).toBeTruthy();
   });
+
+  it("re-renders when slotted children change", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTreeViewItem],
+      html: `
+        <div role="tree">
+          <swirl-tree-view-item item-id="parent" label="Parent"></swirl-tree-view-item>
+        </div>
+      `,
+    });
+
+    expect(page.root.querySelector("[aria-expanded]")).toBeNull();
+
+    const child = document.createElement("swirl-tree-view-item");
+    child.setAttribute("item-id", "child-1");
+    child.setAttribute("label", "Child");
+    page.root.appendChild(child);
+
+    dispatchDefaultSlotChange(page.root);
+    await page.waitForChanges();
+
+    expect(page.root.querySelector('[aria-expanded="false"]')).not.toBeNull();
+
+    page.root.querySelector("swirl-tree-view-item").remove();
+
+    dispatchDefaultSlotChange(page.root);
+    await page.waitForChanges();
+
+    expect(page.root.querySelector("[aria-expanded]")).toBeNull();
+  });
 });
+
+function findDefaultSlotReferenceNode(root: Node): Node | undefined {
+  const walk = (node: Node): Node | undefined => {
+    const slotReferenceNode = node as HTMLElement & {
+      "s-sr"?: boolean;
+      "s-sn"?: string;
+    };
+
+    if (slotReferenceNode["s-sr"] && slotReferenceNode["s-sn"] === "") {
+      return node;
+    }
+
+    for (const childNode of Array.from(node.childNodes)) {
+      const foundNode = walk(childNode);
+
+      if (foundNode) {
+        return foundNode;
+      }
+    }
+
+    return undefined;
+  };
+
+  return walk(root);
+}
+
+function dispatchDefaultSlotChange(root: Node) {
+  const defaultSlotReferenceNode = findDefaultSlotReferenceNode(root);
+  console.log(
+    "dispatchDefaultSlotChange",
+    defaultSlotReferenceNode.textContent
+  );
+
+  defaultSlotReferenceNode?.dispatchEvent(new Event("slotchange"));
+}

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.tsx
@@ -589,7 +589,7 @@ export class SwirlTreeViewItem {
                   : undefined,
             }}
           >
-            <slot></slot>
+            <slot onSlotchange={() => forceUpdate(this.el)}></slot>
           </ul>
         </Tag>
       </Host>


### PR DESCRIPTION
## Summary

## Bug: `swirl-tree-view-item` does not re-render when slotted children change

**Affected component:** `swirl-tree-view-item`

**Bug:** When child `<swirl-tree-view-item>` elements are dynamically added to or removed from the
default slot (e.g. by a framework's conditional rendering), the component does not re-render. This
causes `hasChildren` (computed via `this.el.querySelector("swirl-tree-view-item")` in `render()`)
to remain stale, which results in:
- The children `<ul>` keeping `display: none` when children are added (items invisible)
- The expand/collapse toggle icon not appearing for newly-populated items
- Stale `aria-expanded` and `aria-owns` attributes

**Expected behavior:** The component should re-render when its default slot content changes, so
that `hasChildren` is re-evaluated and the correct visibility/toggle/ARIA state is applied.

**Root cause:** Unlike `swirl-tree-view` (which already listens for `slotchange` on its slot and
calls `this.init()`), `swirl-tree-view-item` has no `slotchange` listener on its default `<slot>`.
Stencil only re-renders when `@Prop` or `@State` values change, so dynamically slotted content is
never detected.

The component already uses `forceUpdate` in its drag-and-drop code paths for the exact same reason
— proving the pattern is established.

**Suggested fix:** Add an `onSlotchange` handler to the default `<slot>` in
`swirl-tree-view-item`'s `render()` method that calls `forceUpdate(this.el)`. This mirrors the
existing pattern in `swirl-tree-view`.

- [Ticket](#)
- [Design](#)
- [Storybook](#)
