### PR TITLE
Fix SwirlProgressIndicator (variant=bar) size heights to and add a new l size for both variants 

### DIFF
--- a/.changeset/fix-progress-bar-sizes.md
+++ b/.changeset/fix-progress-bar-sizes.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Fix SwirlProgressIndicator (variant=bar) size heights to match the design spec (xs: 1px, s: 2px, m: 4px) and add the missing l size (8px)

--- a/.changeset/fix-progress-bar-sizes.md
+++ b/.changeset/fix-progress-bar-sizes.md
@@ -1,5 +1,5 @@
 ---
-"@getflip/swirl-components": patch
+"@getflip/swirl-components": minor
 ---
 
 Fix SwirlProgressIndicator (variant=bar) size heights to match the design spec (xs: 1px, s: 2px, m: 4px) and add the missing l size (8px)

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -46941,7 +46941,7 @@
             {
               "name": "size",
               "type": {
-                "text": "\"m\" | \"s\" | \"xs\"",
+                "text": "\"l\" | \"m\" | \"s\" | \"xs\"",
                 "references": [
                   {
                     "name": "SwirlProgressIndicatorSize"
@@ -46987,7 +46987,7 @@
               "kind": "field",
               "name": "size",
               "type": {
-                "text": "\"m\" | \"s\" | \"xs\"",
+                "text": "\"l\" | \"m\" | \"s\" | \"xs\"",
                 "references": [
                   {
                     "name": "SwirlProgressIndicatorSize"

--- a/packages/swirl-components/src/components/swirl-progress-indicator/swirl-progress-indicator.css
+++ b/packages/swirl-components/src/components/swirl-progress-indicator/swirl-progress-indicator.css
@@ -41,7 +41,23 @@
     }
   }
 
-  &.progress-indicator--size-xs,
+  &.progress-indicator--size-xs {
+    height: 0.0625rem;
+
+    &::-webkit-progress-bar {
+      border-radius: 0.03125rem;
+    }
+
+    &::-webkit-progress-value {
+      border-radius: 0.03125rem;
+    }
+
+    &::-moz-progress-bar {
+      height: 0.0625rem;
+      border-radius: 0.03125rem;
+    }
+  }
+
   &.progress-indicator--size-s {
     height: 0.125rem;
 
@@ -56,6 +72,23 @@
     &::-moz-progress-bar {
       height: 0.125rem;
       border-radius: 0.0625rem;
+    }
+  }
+
+  &.progress-indicator--size-l {
+    height: 0.5rem;
+
+    &::-webkit-progress-bar {
+      border-radius: 0.25rem;
+    }
+
+    &::-webkit-progress-value {
+      border-radius: 0.25rem;
+    }
+
+    &::-moz-progress-bar {
+      height: 0.5rem;
+      border-radius: 0.25rem;
     }
   }
 }
@@ -75,6 +108,11 @@
   &.progress-indicator--size-s {
     width: 1.5rem;
     height: 1.5rem;
+  }
+
+  &.progress-indicator--size-l {
+    width: 6rem;
+    height: 6rem;
   }
 }
 

--- a/packages/swirl-components/src/components/swirl-progress-indicator/swirl-progress-indicator.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-progress-indicator/swirl-progress-indicator.spec.tsx
@@ -47,6 +47,28 @@ describe("swirl-progress-indicator", () => {
     `);
   });
 
+  it("renders a large progress bar", async () => {
+    const page = await newSpecPage({
+      components: [SwirlProgressIndicator],
+      html: `<swirl-progress-indicator label="Progress" size="l" value="60"></swirl-progress-indicator>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <swirl-progress-indicator class="bar" label="Progress" size="l" value="60">
+        <mock:shadow-root>
+          <progress
+            aria-label="Progress"
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="60"
+            class="progress-indicator progress-indicator--size-l progress-indicator--variant-bar"
+            max="100"
+            value="60"></progress>
+        </mock:shadow-root>
+      </swirl-progress-indicator>
+    `);
+  });
+
   it("renders a progress circle", async () => {
     const page = await newSpecPage({
       components: [SwirlProgressIndicator],
@@ -80,6 +102,26 @@ describe("swirl-progress-indicator", () => {
             <svg class="progress-indicator__circle" focusable="false" viewBox="0 0 20 20">
               <circle class="progress-indicator__circle-background" cx="10" cy="10" fill="none" r="8" stroke-width="2"></circle>
               <circle class="progress-indicator__circle-value" cx="10" cy="10" fill="none" r="8" stroke-dasharray="50" stroke-dashoffset="20" stroke-width="2"></circle>
+            </svg>
+          </span>
+        </mock:shadow-root>
+      </swirl-progress-indicator>
+    `);
+  });
+
+  it("renders a large progress circle", async () => {
+    const page = await newSpecPage({
+      components: [SwirlProgressIndicator],
+      html: `<swirl-progress-indicator label="Progress" size="l" value="60" variant="circle"></swirl-progress-indicator>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <swirl-progress-indicator class="circle" label="Progress" size="l" value="60" variant="circle">
+        <mock:shadow-root>
+          <span aria-label="Progress" aria-valuemax="100" aria-valuemin="0" aria-valuenow="60" class="progress-indicator progress-indicator--size-l progress-indicator--variant-circle" role="progressbar">
+            <svg class="progress-indicator__circle" focusable="false" viewBox="0 0 96 96">
+              <circle class="progress-indicator__circle-background" cx="48" cy="48" fill="none" r="40" stroke-width="8"></circle>
+              <circle class="progress-indicator__circle-value" cx="48" cy="48" fill="none" r="40" stroke-dasharray="251" stroke-dashoffset="100" stroke-width="8"></circle>
             </svg>
           </span>
         </mock:shadow-root>

--- a/packages/swirl-components/src/components/swirl-progress-indicator/swirl-progress-indicator.tsx
+++ b/packages/swirl-components/src/components/swirl-progress-indicator/swirl-progress-indicator.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Host, Prop } from "@stencil/core";
 import classnames from "classnames";
 
-export type SwirlProgressIndicatorSize = "xs" | "s" | "m";
+export type SwirlProgressIndicatorSize = "xs" | "s" | "m" | "l";
 
 export type SwirlProgressIndicatorVariant = "bar" | "circle";
 
@@ -12,6 +12,7 @@ const circleSizeConfig: Record<
   xs: { radius: 8, strokeWidth: 2 },
   s: { radius: 10, strokeWidth: 2 },
   m: { radius: 20, strokeWidth: 4 },
+  l: { radius: 40, strokeWidth: 8 },
 };
 
 @Component({

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -22091,6 +22091,9 @@
           "description": "",
           "values": [
             {
+              "name": "l"
+            },
+            {
               "name": "m"
             },
             {


### PR DESCRIPTION
## Summary

`swirl-progress-indicator`'s `bar` variant rendered `xs` and `s` at the same height (2px) and had no `l` size. This updates the CSS to match the desired size mapping and adds the missing `l` size.

**Before → after (bar height)**

| size | before | after |
|------|--------|-------|
| xs   | 2px    | 1px   |
| s    | 2px    | 2px (unchanged) |
| m    | 4px    | 4px (unchanged, still default) |
| l    | n/a    | 8px (new) |

Since `size` is shared with the `circle` variant, and `circleSizeConfig` is a `Record<SwirlProgressIndicatorSize, ...>` requiring every key, I added a proportional `l` entry for `circle` too (`radius: 40, strokeWidth: 8` — double the `m` config, matching the existing `s`→`m` stroke/diameter ratio). No spec called out circle geometry for `l`, so flagging this choice for review.

## What a reviewer should know

- `custom-elements.manifest.json` and `vscode-data.json` are regenerated build artifacts (via `stencil build`) reflecting the new `l` size in the type union — not hand-edited.
- Added spec coverage for the new `l` size on both `bar` and `circle` variants.
- Added a changeset (`patch`).

## Test plan

- [x] `stencil test --spec` — all 508 tests pass (including new `l`-size cases)
- [x] `eslint` on changed files — clean
- [x] Verified in a local Storybook build: `xs`/`s`/`m`/`l` bar heights measured via computed style match 1px/2px/4px/8px; unset `size` still resolves to the `m` default (4px)