### PR TITLE
Tree view custom icons

### DIFF
--- a/.changeset/cool-spies-occur.md
+++ b/.changeset/cool-spies-occur.md
@@ -1,0 +1,9 @@
+---
+"@getflip/swirl-ai": minor
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Update SwirlTreeView to support custom expand/collapse icons, remove drag handle
+and add grouping line on nested items

--- a/packages/swirl-components/.storybook/preview-head.html
+++ b/packages/swirl-components/.storybook/preview-head.html
@@ -32,7 +32,7 @@
     color: rgba(0, 0, 0, 1);
   }
 
-  @scope (.sbdocs) to (.sbdocs-preview) {
+  @scope (.sbdocs) to (.docs-story) {
     h1,
     h2,
     h3,

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -63804,6 +63804,13 @@
           "name": "SwirlTreeView",
           "attributes": [
             {
+              "name": "collapsed-icon",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "collapsedIcon"
+            },
+            {
               "name": "drag-drop-item-selector",
               "type": {
                 "text": "string"
@@ -63817,6 +63824,13 @@
                 "text": "boolean"
               },
               "fieldName": "enableDragDrop"
+            },
+            {
+              "name": "expanded-icon",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "expandedIcon"
             },
             {
               "name": "label",
@@ -63855,6 +63869,15 @@
             },
             {
               "kind": "field",
+              "name": "collapsedIcon",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "collapsed-icon"
+            },
+            {
+              "kind": "field",
               "name": "dragDropInstructions",
               "type": {
                 "text": "{ cannotBeDropped: string; end: string; initial: string; moved: string; start: string; }"
@@ -63880,6 +63903,15 @@
               },
               "readonly": true,
               "attribute": "enable-drag-drop"
+            },
+            {
+              "kind": "field",
+              "name": "expandedIcon",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "expanded-icon"
             },
             {
               "kind": "field",
@@ -64005,6 +64037,13 @@
               "fieldName": "active"
             },
             {
+              "name": "collapsed-icon",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "collapsedIcon"
+            },
+            {
               "name": "disable-drag",
               "type": {
                 "text": "boolean"
@@ -64018,6 +64057,13 @@
               },
               "default": "true",
               "fieldName": "expandable"
+            },
+            {
+              "name": "expanded-icon",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "expandedIcon"
             },
             {
               "name": "href",
@@ -64073,6 +64119,15 @@
             },
             {
               "kind": "field",
+              "name": "collapsedIcon",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "collapsed-icon"
+            },
+            {
+              "kind": "field",
               "name": "disableDrag",
               "type": {
                 "text": "boolean"
@@ -64089,6 +64144,15 @@
               "default": "true",
               "readonly": true,
               "attribute": "expandable"
+            },
+            {
+              "kind": "field",
+              "name": "expandedIcon",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "expanded-icon"
             },
             {
               "kind": "field",

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -5735,6 +5735,7 @@ export namespace Components {
     }
     interface SwirlTreeView {
         "canDrop"?: SwirlTreeViewCanDropHandler;
+        "collapsedIcon"?: string;
         /**
           * @default defaultDragDropInstructions
          */
@@ -5745,6 +5746,7 @@ export namespace Components {
         "dragDropItemSelector"?: string;
         "enableDragDrop"?: boolean;
         "expandItems": (itemIds: string[]) => Promise<void>;
+        "expandedIcon"?: string;
         "initiallyExpandedItemIds"?: string[];
         "label": string;
         /**
@@ -5755,12 +5757,14 @@ export namespace Components {
     interface SwirlTreeViewItem {
         "active"?: boolean;
         "collapse": () => Promise<void>;
+        "collapsedIcon"?: string;
         "disableDrag"?: boolean;
         "expand": () => Promise<void>;
         /**
           * @default true
          */
         "expandable"?: boolean;
+        "expandedIcon"?: string;
         "href"?: string;
         "icon"?: string;
         "iconColor"?: SwirlIconColor1;
@@ -15729,6 +15733,7 @@ declare namespace LocalJSX {
     }
     interface SwirlTreeView {
         "canDrop"?: SwirlTreeViewCanDropHandler;
+        "collapsedIcon"?: string;
         /**
           * @default defaultDragDropInstructions
          */
@@ -15738,6 +15743,7 @@ declare namespace LocalJSX {
          */
         "dragDropItemSelector"?: string;
         "enableDragDrop"?: boolean;
+        "expandedIcon"?: string;
         "initiallyExpandedItemIds"?: string[];
         "label": string;
         "onDropItem"?: (event: SwirlTreeViewCustomEvent<SwirlTreeViewDropItemEvent>) => void;
@@ -15752,11 +15758,13 @@ declare namespace LocalJSX {
     }
     interface SwirlTreeViewItem {
         "active"?: boolean;
+        "collapsedIcon"?: string;
         "disableDrag"?: boolean;
         /**
           * @default true
          */
         "expandable"?: boolean;
+        "expandedIcon"?: string;
         "href"?: string;
         "icon"?: string;
         "iconColor"?: SwirlIconColor1;
@@ -18655,15 +18663,19 @@ declare namespace LocalJSX {
         "external": boolean;
     }
     interface SwirlTreeViewAttributes {
+        "collapsedIcon": string;
         "dragDropItemSelector": string;
         "enableDragDrop": boolean;
+        "expandedIcon": string;
         "label": string;
         "semantics": SwirlTreeViewSemantics;
     }
     interface SwirlTreeViewItemAttributes {
         "active": boolean;
+        "collapsedIcon": string;
         "disableDrag": boolean;
         "expandable": boolean;
+        "expandedIcon": string;
         "href": string;
         "icon": string;
         "iconColor": SwirlIconColor;

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.css
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.css
@@ -19,26 +19,12 @@ swirl-tree-view-item {
 
   & .tree-view-item__link {
     background-color: var(--s-translucent-low-pressed);
-
-    &:hover {
-      & .tree-view-item__drag-handle {
-        opacity: 0;
-      }
-    }
   }
 }
 
 .tree-view-item--ghost {
   border: var(--s-border-width-default) solid var(--s-border-highlight);
   border-radius: var(--s-border-radius-sm);
-
-  & .tree-view-item__link {
-    &:hover {
-      & .tree-view-item__drag-handle {
-        opacity: 0;
-      }
-    }
-  }
 }
 
 .tree-view-item--moving-via-keyboard {
@@ -101,10 +87,6 @@ swirl-tree-view-item {
 
   &:hover {
     background-color: var(--s-state-hovered);
-
-    & .tree-view-item__drag-handle {
-      opacity: 1;
-    }
   }
 
   &:active {
@@ -121,17 +103,6 @@ swirl-tree-view-item {
 
   @media (--from-desktop-without-touch) {
     font-size: var(--s-font-size-sm);
-  }
-}
-
-.tree-view-item__drag-handle {
-  display: inline-flex;
-  flex-shrink: 0;
-  cursor: grab;
-  opacity: 0;
-
-  &:active {
-    cursor: grabbing;
   }
 }
 

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.css
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.css
@@ -10,7 +10,13 @@ swirl-tree-view-item {
 }
 
 .tree-view-item {
+  --tree-view-item-toggle-icon-size: 1.5rem;
+
   list-style: none;
+
+  @media (--from-desktop-without-touch) {
+    --tree-view-item-toggle-icon-size: 1.25rem;
+  }
 }
 
 .tree-view-item--chosen.tree-view-item--drag:not(.tree-view-item--ghost) {
@@ -60,10 +66,11 @@ swirl-tree-view-item {
 }
 
 .tree-view-item__children {
+  position: relative;
   display: flex;
   margin: 0;
-  padding: 0 0 0 var(--s-space-12);
-  padding-top: var(--s-space-2);
+  padding: var(--s-space-2) 0 0
+    calc(var(--tree-view-item-toggle-icon-size) + var(--s-space-4));
   flex-direction: column;
   gap: var(--s-space-2);
 }
@@ -71,6 +78,21 @@ swirl-tree-view-item {
 .tree-view-item__children--drop-zone {
   min-height: 0.5rem;
   margin-top: -0.5rem;
+}
+
+li.tree-view-item > .tree-view-item__children::before {
+  content: "";
+  position: absolute;
+  top: var(--s-space-2);
+  bottom: 0;
+  left: calc(var(--s-space-8) + var(--tree-view-item-toggle-icon-size) / 2);
+  width: var(--s-border-width-default);
+  height: calc(100% - var(--s-space-2));
+  background-color: var(--s-border-default);
+}
+
+li.tree-view-item > .tree-view-item__children--drop-zone::before {
+  content: none;
 }
 
 .tree-view-item__link {
@@ -130,8 +152,8 @@ swirl-tree-view-item {
 
 .tree-view-item__toggle-icon {
   display: block;
-  width: 1.5rem;
-  height: 1.5rem;
+  width: var(--tree-view-item-toggle-icon-size);
+  height: var(--tree-view-item-toggle-icon-size);
   flex-grow: 0;
   flex-shrink: 0;
   color: var(--s-icon-default);
@@ -139,11 +161,6 @@ swirl-tree-view-item {
   & ::part(icon) {
     width: 100%;
     height: 100%;
-  }
-
-  @media (--from-desktop-without-touch) {
-    width: 1.25rem;
-    height: 1.25rem;
   }
 }
 

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.mdx
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.mdx
@@ -23,6 +23,24 @@ The SwirlTreeViewItem component is used to render nodes in a
   code={`<swirl-tree-view-item href="#" icon="🪁" item-id="item" label="Label"></swirl-tree-view-item>`}
 />
 
+## Custom expand/collapse icons
+
+Set `expanded-icon`/`collapsed-icon` to override the toggle icons for this
+item (and any descendant that doesn't set its own). Without these props, the
+item falls back to the `expanded-icon`/`collapsed-icon` set on the parent
+[swirl-tree-view](?path=/docs/components-swirltreeview--docs), or to
+`expand-more`/`chevron-right` if neither is set.
+
+<Source
+  code={`<swirl-tree-view-item
+    collapsed-icon="folder"
+    expanded-icon="folder-open"
+    href="#"
+    item-id="item"
+    label="Label"
+></swirl-tree-view-item>`}
+/>
+
 ## Related components
 
 - **[swirl-tree-view](?path=/docs/components-swirltreeview--docs)** (parent) —

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.spec.tsx
@@ -1,5 +1,6 @@
 import { newSpecPage } from "@stencil/core/testing";
 
+import { SwirlTreeView } from "../swirl-tree-view/swirl-tree-view";
 import { SwirlTreeViewItem } from "./swirl-tree-view-item";
 
 describe("swirl-tree-view-item", () => {
@@ -90,5 +91,51 @@ describe("swirl-tree-view-item", () => {
     await page.waitForChanges();
 
     expect(page.root.querySelector('[aria-selected="true"]')).toBeTruthy();
+  });
+
+  it("uses custom expanded/collapsed icons from the tree view, overridable per item", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTreeView, SwirlTreeViewItem],
+      html: `
+        <swirl-tree-view label="Tree" expanded-icon="remove" collapsed-icon="add">
+          <swirl-tree-view-item item-id="1" label="Inherits tree icons">
+            <swirl-tree-view-item item-id="2" label="Child"></swirl-tree-view-item>
+          </swirl-tree-view-item>
+          <swirl-tree-view-item
+            item-id="3"
+            label="Overrides tree icons"
+            expanded-icon="folder-open"
+            collapsed-icon="folder"
+          >
+            <swirl-tree-view-item item-id="4" label="Child"></swirl-tree-view-item>
+          </swirl-tree-view-item>
+        </swirl-tree-view>
+      `,
+    });
+
+    const inheritingItem = page.root.querySelector(
+      '[item-id="1"]'
+    ) as HTMLSwirlTreeViewItemElement;
+    const overridingItem = page.root.querySelector(
+      '[item-id="3"]'
+    ) as HTMLSwirlTreeViewItemElement;
+
+    expect(
+      inheritingItem.querySelector("swirl-icon")?.getAttribute("glyph")
+    ).toBe("add");
+    expect(
+      overridingItem.querySelector("swirl-icon")?.getAttribute("glyph")
+    ).toBe("folder");
+
+    await inheritingItem.expand();
+    await overridingItem.expand();
+    await page.waitForChanges();
+
+    expect(
+      inheritingItem.querySelector("swirl-icon")?.getAttribute("glyph")
+    ).toBe("remove");
+    expect(
+      overridingItem.querySelector("swirl-icon")?.getAttribute("glyph")
+    ).toBe("folder-open");
   });
 });

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.tsx
@@ -545,11 +545,6 @@ export class SwirlTreeViewItem {
             role={semantics === "tree" ? "treeitem" : undefined}
             tabIndex={tabIndex}
           >
-            {!this.disableDrag && this.enableDragDrop && (
-              <span class="tree-view-item__drag-handle">
-                <swirl-icon-drag-handle size={20}></swirl-icon-drag-handle>
-              </span>
-            )}
             {this.expandable && semantics === "tree" && (
               <span class="tree-view-item__toggle-icon">
                 {hasChildren && (

--- a/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view-item/swirl-tree-view-item.tsx
@@ -42,8 +42,10 @@ export class SwirlTreeViewItem {
   @Element() el!: HTMLSwirlTreeViewItemElement;
 
   @Prop() active?: boolean;
+  @Prop() collapsedIcon?: string;
   @Prop() disableDrag?: boolean;
   @Prop() expandable?: boolean = true;
+  @Prop() expandedIcon?: string;
   @Prop() href?: string;
   @Prop() icon?: string;
   @Prop() iconColor?: SwirlIconColor;
@@ -68,6 +70,8 @@ export class SwirlTreeViewItem {
   @State() level = 0;
   @State() movingViaKeyboard = false;
   @State() selected = false;
+  @State() treeCollapsedIcon?: string;
+  @State() treeExpandedIcon?: string;
 
   private childList?: HTMLElement;
   private positionBeforeKeyboardMove?: {
@@ -85,6 +89,14 @@ export class SwirlTreeViewItem {
     this.enableDragDrop = treeView?.enableDragDrop;
     this.canDrop = treeView?.canDrop;
     this.dragDropItemSelector = treeView?.dragDropItemSelector;
+    this.treeCollapsedIcon =
+      treeView?.collapsedIcon ??
+      treeView?.getAttribute("collapsed-icon") ??
+      undefined;
+    this.treeExpandedIcon =
+      treeView?.expandedIcon ??
+      treeView?.getAttribute("expanded-icon") ??
+      undefined;
   }
 
   componentDidLoad() {
@@ -485,6 +497,11 @@ export class SwirlTreeViewItem {
 
     const shouldShowChildrenDropZone = this.enableDragDrop && !hasChildren;
 
+    const expandedGlyph =
+      this.expandedIcon ?? this.treeExpandedIcon ?? "expand-more";
+    const collapsedGlyph =
+      this.collapsedIcon ?? this.treeCollapsedIcon ?? "chevron-right";
+
     const semantics = this.getSemantics();
     const expanded = this.expanded || semantics !== "tree";
     const tabIndex =
@@ -538,15 +555,17 @@ export class SwirlTreeViewItem {
                 {hasChildren && (
                   <Fragment>
                     {expanded ? (
-                      <swirl-icon-expand-more
+                      <swirl-icon
+                        glyph={expandedGlyph}
                         onClick={this.onClickCollapse}
                         size={24}
-                      ></swirl-icon-expand-more>
+                      ></swirl-icon>
                     ) : (
-                      <swirl-icon-chevron-right
+                      <swirl-icon
+                        glyph={collapsedGlyph}
                         onClick={this.onClickExpand}
                         size={24}
-                      ></swirl-icon-chevron-right>
+                      ></swirl-icon>
                     )}
                   </Fragment>
                 )}

--- a/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.css
+++ b/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.css
@@ -24,9 +24,5 @@ swirl-tree-view {
   & .tree-view-item__link:hover,
   & .tree-view-item__link:active {
     background-color: var(--s-background-default) !important;
-
-    & .tree-view-item__drag-handle {
-      opacity: 0;
-    }
   }
 }

--- a/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.mdx
+++ b/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.mdx
@@ -40,6 +40,22 @@ hierarchical list of items.
 </swirl-tree-view>`}
 />
 
+## Custom expand/collapse icons
+
+By default, tree view items use `expand-more`/`chevron-right` as their
+expand/collapse toggle icons. Set `expanded-icon`/`collapsed-icon` on
+`swirl-tree-view` to change the default for every item in the tree; set the
+same props on an individual `swirl-tree-view-item` to override it for that
+item (and its descendants that don't set their own).
+
+<Source
+  code={`<swirl-tree-view collapsed-icon="add" expanded-icon="remove" label="Tree view">
+    <swirl-tree-view-item item-id="item-1" label="Item 1">
+        <swirl-tree-view-item item-id="item-1-1" label="Item 1.1"></swirl-tree-view-item>
+    </swirl-tree-view-item>
+</swirl-tree-view>`}
+/>
+
 ## Related components
 
 - **[swirl-tree-view-item](?path=/docs/components-swirltreeviewitem--docs)**

--- a/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.spec.tsx
@@ -36,7 +36,7 @@ describe("swirl-tree-view", () => {
             <li class="tree-view-item" role="none">
               <a aria-expanded="false" aria-level="1" aria-owns="undefined-children" aria-selected="true" class="tree-view-item__link" href="#" role="treeitem" tabindex="0">
                 <span class="tree-view-item__toggle-icon">
-                  <swirl-icon-chevron-right size="24"></swirl-icon-chevron-right>
+                  <swirl-icon glyph="chevron-right" size="24"></swirl-icon>
                 </span>
                 <span class="tree-view-item__icon">
                   🪁
@@ -68,7 +68,7 @@ describe("swirl-tree-view", () => {
                   <li class="tree-view-item" role="none">
                     <a aria-expanded="false" aria-level="2" aria-owns="undefined-children" aria-selected="false" class="tree-view-item__link" href="#" role="treeitem" tabindex="-1">
                       <span class="tree-view-item__toggle-icon">
-                        <swirl-icon-chevron-right size="24"></swirl-icon-chevron-right>
+                        <swirl-icon glyph="chevron-right" size="24"></swirl-icon>
                       </span>
                       <span class="tree-view-item__icon">
                         🌎
@@ -157,7 +157,7 @@ describe("swirl-tree-view", () => {
             <li class="tree-view-item" role="none">
               <a aria-expanded="false" aria-level="1" aria-owns="undefined-children" aria-selected="false" class="tree-view-item__link" href="#" role="treeitem" tabindex="-1">
                 <span class="tree-view-item__toggle-icon">
-                  <swirl-icon-chevron-right size="24"></swirl-icon-chevron-right>
+                  <swirl-icon glyph="chevron-right" size="24"></swirl-icon>
                 </span>
                 <span class="tree-view-item__icon">
                   🎮

--- a/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.tsx
+++ b/packages/swirl-components/src/components/swirl-tree-view/swirl-tree-view.tsx
@@ -57,9 +57,11 @@ export class SwirlTreeView {
   @Element() el!: HTMLSwirlTreeViewElement;
 
   @Prop() canDrop?: SwirlTreeViewCanDropHandler;
+  @Prop() collapsedIcon?: string;
   @Prop() dragDropInstructions = defaultDragDropInstructions;
   @Prop() dragDropItemSelector?: string = "swirl-tree-view-item";
   @Prop() enableDragDrop?: boolean;
+  @Prop() expandedIcon?: string;
   @Prop() initiallyExpandedItemIds?: string[];
   @Prop() label!: string;
   @Prop() semantics?: SwirlTreeViewSemantics = "tree";

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -26788,11 +26788,19 @@
       },
       "attributes": [
         {
+          "name": "collapsed-icon",
+          "description": ""
+        },
+        {
           "name": "drag-drop-item-selector",
           "description": ""
         },
         {
           "name": "enable-drag-drop",
+          "description": ""
+        },
+        {
+          "name": "expanded-icon",
           "description": ""
         },
         {
@@ -26825,11 +26833,19 @@
           "description": ""
         },
         {
+          "name": "collapsed-icon",
+          "description": ""
+        },
+        {
           "name": "disable-drag",
           "description": ""
         },
         {
           "name": "expandable",
+          "description": ""
+        },
+        {
+          "name": "expanded-icon",
           "description": ""
         },
         {


### PR DESCRIPTION
## Summary

SwirlTreeView

- Remove drag handle
- Support custom expand and collapse icons
- Add grouping line on child items

- [Ticket](#)
- [Design](#)
- [Storybook](#)
