### PR TITLE
Prevent SwirlLightbox keyboard controls from interfering with video player controls

### DIFF
--- a/.changeset/rotten-pets-divide.md
+++ b/.changeset/rotten-pets-divide.md
@@ -1,0 +1,6 @@
+---
+"@getflip/swirl-components": patch
+---
+
+Prevent swirl-lightbox from interfering with native video player keyboard
+controls

--- a/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-video/swirl-file-viewer-video.tsx
+++ b/packages/swirl-components/src/components/swirl-file-viewer/viewers/swirl-file-viewer-video/swirl-file-viewer-video.tsx
@@ -129,6 +129,10 @@ export class SwirlFileViewerVideo {
     this.playbackEnded.emit(this.getPlaybackDetail());
   };
 
+  private onKeyDown = (event: Event) => {
+    event.stopPropagation();
+  };
+
   render() {
     return (
       <Host class="file-viewer-video">
@@ -137,6 +141,7 @@ export class SwirlFileViewerVideo {
           class="file-viewer-video__video"
           controls
           onEnded={this.onNativeEnded}
+          onKeyDown={this.onKeyDown}
           onPause={this.onNativePause}
           onPlay={this.onNativePlay}
           onRateChange={this.onNativeRateChange}


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/COR-98/allow-default-arrow-controls-for-videos-in-lightboxes)
