### PR TITLE
Support swirl-resource-list-item meta text and badges when selectable

### DIFF
--- a/.changeset/proud-beers-double.md
+++ b/.changeset/proud-beers-double.md
@@ -1,0 +1,6 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Support swirl-resource-list-item meta text and badges slot when item is
+selectable

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.css
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.css
@@ -112,13 +112,15 @@
 
 .resource-list-item--selectable {
   & .resource-list-item__content {
+    padding-left: calc(var(--s-space-16) + 0.75rem + var(--s-space-12));
+
     @media (--from-tablet) {
       padding-left: calc(var(--s-space-16) + 1.5rem + var(--s-space-12));
     }
   }
 
   & .resource-list-item__label-container {
-    padding-right: calc(var(--s-space-16) + 1.5rem + var(--s-space-12));
+    padding-right: var(--s-space-8);
 
     @media (--from-tablet) {
       padding-right: var(--s-space-16);
@@ -321,7 +323,7 @@
 .resource-list-item__checkbox {
   position: absolute;
   top: 50%;
-  right: var(--s-space-16);
+  left: calc(var(--s-space-16) - var(--s-space-2));
   display: flex;
   width: 1.125rem;
   height: 1.125rem;
@@ -331,11 +333,6 @@
   border-radius: var(--s-border-radius-s);
   transform: translateY(-50%);
   pointer-events: none;
-
-  @media (--from-tablet) {
-    right: auto;
-    left: calc(var(--s-space-16) - var(--s-space-2));
-  }
 }
 
 .resource-list-item__checkbox-icon {

--- a/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
+++ b/packages/swirl-components/src/components/swirl-resource-list-item/swirl-resource-list-item.tsx
@@ -107,7 +107,7 @@ export class SwirlResourceListItem {
   }
 
   private get showMeta() {
-    return (Boolean(this.meta) || this.hasBadges) && !this.selectable;
+    return Boolean(this.meta) || this.hasBadges;
   }
 
   private forceIconProps(smallIcon: boolean) {


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/COR-108/resource-list-item-alignment-is-wrong-when-selectable-is-enabled)
