### PR TITLE
Support square avatars in swirl-avatar-group

### DIFF
--- a/.changeset/square-avatars-in-avatar-group.md
+++ b/.changeset/square-avatars-in-avatar-group.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Support square avatars in swirl-avatar-group

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -2410,7 +2410,8 @@
               },
               "default": "\"m\"",
               "readonly": true,
-              "attribute": "size"
+              "attribute": "size",
+              "reflects": true
             },
             {
               "kind": "field",
@@ -2449,7 +2450,8 @@
               },
               "default": "\"round\"",
               "readonly": true,
-              "attribute": "variant"
+              "attribute": "variant",
+              "reflects": true
             }
           ],
           "events": [

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.css
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.css
@@ -18,7 +18,7 @@
   & ::slotted(*:first-child) {
     z-index: 1;
     display: inline-flex;
-    border-radius: 50%;
+    border-radius: var(--swirl-avatar-radius, 50%);
     box-shadow: 0 0 0 0.25rem var(--swirl-avatar-group-border-color);
     background-color: var(--swirl-avatar-group-border-color);
     grid-column-start: 1;
@@ -30,7 +30,7 @@
   & ::slotted(*:nth-child(2)) {
     z-index: 0;
     display: inline-flex;
-    border-radius: 50%;
+    border-radius: var(--swirl-avatar-radius, 50%);
     grid-column-start: 4;
     grid-column-end: 10;
     grid-row-start: 1;
@@ -58,7 +58,7 @@
   & ::slotted(*) {
     z-index: 1;
     display: inline-flex;
-    border-radius: 50%;
+    border-radius: var(--swirl-avatar-radius, 50%);
     box-shadow: 0 0 0 0.125rem var(--swirl-avatar-group-border-color);
     background-color: var(--swirl-avatar-group-border-color);
   }

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.stories.ts
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.stories.ts
@@ -59,3 +59,21 @@ export const WithHorizontalLayout = TemplateWithHorizontalLayout.bind({});
 WithHorizontalLayout.args = {
   layout: "horizontal",
 };
+
+const TemplateWithSquareAvatars = (args) => {
+  const element = generateStoryElement("swirl-avatar-group", args);
+
+  element.innerHTML = `
+    <swirl-avatar label="Jane Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a" size="xs" variant="square"></swirl-avatar>
+    <swirl-avatar label="John Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=b" size="xs" variant="square"></swirl-avatar>
+    <swirl-avatar label="Jack Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=c" size="xs" variant="square"></swirl-avatar>
+  `;
+
+  return element;
+};
+
+export const WithSquareAvatars = TemplateWithSquareAvatars.bind({});
+
+WithSquareAvatars.args = {
+  layout: "horizontal",
+};

--- a/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.css
+++ b/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.css
@@ -3,10 +3,37 @@
   flex-shrink: 0;
   align-items: center;
   flex-direction: column;
+  --swirl-avatar-radius: 50%;
 
   & * {
     box-sizing: border-box;
   }
+}
+
+:host([variant="square"][size="3xs"]),
+:host([variant="square"][size="2xs"]) {
+  --swirl-avatar-radius: 0.25rem;
+}
+
+:host([variant="square"][size="xs"]),
+:host([variant="square"][size="s"]) {
+  --swirl-avatar-radius: 0.5rem;
+}
+
+:host([variant="square"][size="m"]) {
+  --swirl-avatar-radius: 0.625rem;
+}
+
+:host([variant="square"][size="l"]) {
+  --swirl-avatar-radius: 0.75rem;
+}
+
+:host([variant="square"][size="xl"]) {
+  --swirl-avatar-radius: 1rem;
+}
+
+:host([variant="square"][size="2xl"]) {
+  --swirl-avatar-radius: 1.25rem;
 }
 
 .avatar {
@@ -14,7 +41,7 @@
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  border-radius: 50%;
+  border-radius: var(--swirl-avatar-radius);
   border: var(--swirl-avatar-border-width, 0) solid
     var(--swirl-avatar-border-color, transparent);
 }
@@ -54,12 +81,6 @@
     padding-right: 0.125rem;
     padding-left: 0.125rem;
   }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 0.25rem;
-  }
 }
 
 .avatar--size-2xs {
@@ -73,12 +94,6 @@
   &.avatar--has-icon {
     padding-right: 0.125rem;
     padding-left: 0.125rem;
-  }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 0.25rem;
   }
 }
 
@@ -94,12 +109,6 @@
     padding-right: 0.4375rem;
     padding-left: 0.4375rem;
   }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 0.5rem;
-  }
 }
 
 .avatar--size-s {
@@ -113,12 +122,6 @@
   &.avatar--has-icon {
     padding-right: var(--s-space-8);
     padding-left: var(--s-space-8);
-  }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 0.5rem;
   }
 }
 
@@ -134,12 +137,6 @@
     padding-right: 0.625rem;
     padding-left: 0.625rem;
   }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 0.625rem;
-  }
 }
 
 .avatar--size-l {
@@ -153,12 +150,6 @@
   &.avatar--has-icon {
     padding-right: var(--s-space-12);
     padding-left: var(--s-space-12);
-  }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 0.75rem;
   }
 }
 
@@ -174,12 +165,6 @@
     padding-right: var(--s-space-16);
     padding-left: var(--s-space-16);
   }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 1rem;
-  }
 }
 
 .avatar--size-2xl {
@@ -193,12 +178,6 @@
   &.avatar--has-icon {
     padding-right: var(--s-space-32);
     padding-left: var(--s-space-32);
-  }
-
-  &.avatar--variant-square,
-  &.avatar--variant-square .avatar__image,
-  &.avatar--variant-square .avatar__initials {
-    border-radius: 1.25rem;
   }
 
   & .avatar__tool {
@@ -270,7 +249,7 @@
   overflow: hidden;
   width: 100%;
   height: 100%;
-  border-radius: 50%;
+  border-radius: var(--swirl-avatar-radius);
 
   & > img {
     width: 100%;
@@ -302,7 +281,7 @@
   padding-left: 0.0625rem;
   justify-content: center;
   align-items: center;
-  border-radius: 50%;
+  border-radius: var(--swirl-avatar-radius);
   font-weight: var(--s-font-weight-medium);
   inset: 0;
 

--- a/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.spec.tsx
@@ -10,7 +10,7 @@ describe("swirl-avatar", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <swirl-avatar label="John Doe">
+      <swirl-avatar label="John Doe" size="m" variant="round">
         <mock:shadow-root>
           <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
@@ -39,7 +39,7 @@ describe("swirl-avatar", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <swirl-avatar label="John Doe" src="https://">
+      <swirl-avatar label="John Doe" size="m" src="https://" variant="round">
         <mock:shadow-root>
           <span class="avatar avatar--color-kiwi avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__image">
@@ -61,7 +61,7 @@ describe("swirl-avatar", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <swirl-avatar initials="JD" label="John Doe">
+      <swirl-avatar initials="JD" label="John Doe" size="m" variant="round">
         <mock:shadow-root>
           <span class="avatar avatar--color-kiwi avatar--has-initials avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__initials">
@@ -85,7 +85,7 @@ describe("swirl-avatar", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <swirl-avatar icon="<swirl-icon-close></swirl-icon-close>" label="John Doe">
+      <swirl-avatar icon="<swirl-icon-close></swirl-icon-close>" label="John Doe" size="m" variant="round">
         <mock:shadow-root>
           <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
@@ -153,7 +153,7 @@ describe("swirl-avatar", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <swirl-avatar badge="<swirl-badge aria-label='3 new messages' label='3'></swirl-badge>" badge-position="top" label="John Doe">
+      <swirl-avatar badge="<swirl-badge aria-label='3 new messages' label='3'></swirl-badge>" badge-position="top" label="John Doe" size="m" variant="round">
         <mock:shadow-root>
           <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
@@ -178,7 +178,7 @@ describe("swirl-avatar", () => {
     });
 
     expect(page.root).toEqualHtml(`
-      <swirl-avatar label="John Doe" show-label="">
+      <swirl-avatar label="John Doe" show-label="" size="m" variant="round">
         <mock:shadow-root>
           <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
@@ -215,5 +215,22 @@ describe("swirl-avatar", () => {
     await page.waitForChanges();
 
     expect(buttonSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("reflects size and variant to attributes so ancestors can style by them", async () => {
+    const page = await newSpecPage({
+      components: [SwirlAvatar],
+      html: `<swirl-avatar label="John Doe"></swirl-avatar>`,
+    });
+
+    expect(page.root.getAttribute("size")).toBe("m");
+    expect(page.root.getAttribute("variant")).toBe("round");
+
+    page.root.setAttribute("variant", "square");
+    page.root.setAttribute("size", "s");
+    await page.waitForChanges();
+
+    expect(page.root.getAttribute("size")).toBe("s");
+    expect(page.root.getAttribute("variant")).toBe("square");
   });
 });

--- a/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
@@ -70,10 +70,10 @@ export class SwirlAvatar {
   @Prop() label!: string;
   @Prop() loading?: SwirlAvatarLoading;
   @Prop() showLabel?: boolean = false;
-  @Prop() size?: SwirlAvatarSize = "m";
+  @Prop({ reflect: true }) size?: SwirlAvatarSize = "m";
   @Prop() src?: string;
   @Prop() toolPosition?: SwirlAvatarToolPosition = "bottom";
-  @Prop() variant?: SwirlAvatarVariant = "round";
+  @Prop({ reflect: true }) variant?: SwirlAvatarVariant = "round";
 
   @State() loadingError = false;
   @State() loaded = false;


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/COR-2064/flipweb-allow-multi-selection-of-channels-on-post-creation)
- [Design](https://www.figma.com/design/na3s6HPCyd9aMfAazCI0oK/Multi-channel-posting?node-id=163-25378&m=dev)
