### PR TITLE
feat: support a status badge on swirl-tab-bar tabs

### DIFF
--- a/.changeset/swirl-tab-bar-status-badge.md
+++ b/.changeset/swirl-tab-bar-status-badge.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Add an optional status badge to swirl-tab-bar tabs and swirl-tab.

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -60453,6 +60453,20 @@
             },
             {
               "kind": "field",
+              "name": "badge",
+              "type": {
+                "text": "{ intent?: SwirlBadgeIntent; label: string; }",
+                "references": [
+                  {
+                    "name": "SwirlTabBarTabBadge",
+                    "module": "../swirl-tab-bar/swirl-tab-bar"
+                  }
+                ]
+              },
+              "readonly": true
+            },
+            {
+              "kind": "field",
               "name": "icon",
               "type": {
                 "text": "string"

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -71,11 +71,11 @@ import { SwirlStackAlign, SwirlStackJustify, SwirlStackOrientation, SwirlStackSp
 import { SwirlStatusIndicatorIntent } from "./components/swirl-status-indicator/swirl-status-indicator";
 import { SwirlSwitchLabelPosition } from "./components/swirl-switch/swirl-switch";
 import { SwirlSymbolSize } from "./components/swirl-symbol/swirl-symbol.types";
+import { SwirlTabBarJustify as SwirlTabBarJustify1, SwirlTabBarPadding as SwirlTabBarPadding1, SwirlTabBarTabBadge, SwirlTabBarVariant as SwirlTabBarVariant1 } from "./components/swirl-tab-bar/swirl-tab-bar";
 import { SwirlTabPadding } from "./components/swirl-tab/swirl-tab";
 import { SwirlTabBarJustify, SwirlTabBarPadding, SwirlTabBarTab, SwirlTabBarVariant } from "./components/swirl-tab-bar/swirl-tab-bar";
 import { SwirlTableDropRowEvent } from "./components/swirl-table/swirl-table";
 import { SwirlTableColumnSort, SwirlTableColumnVariant } from "./components/swirl-table-column/swirl-table-column";
-import { SwirlTabBarJustify as SwirlTabBarJustify1, SwirlTabBarPadding as SwirlTabBarPadding1, SwirlTabBarVariant as SwirlTabBarVariant1 } from "./components/swirl-tab-bar/swirl-tab-bar";
 import { SwirlTagIconPosition, SwirlTagIntent, SwirlTagSize, SwirlTagVariant } from "./components/swirl-tag/swirl-tag";
 import { SwirlTextAlign, SwirlTextColor, SwirlTextFontFamily, SwirlTextFontStyle, SwirlTextSize, SwirlTextTruncateDirection, SwirlTextWeight, SwirlTextWhiteSpace } from "./components/swirl-text/swirl-text";
 import { SwirlTextInputFontSize, SwirlTextInputMode as SwirlTextInputMode1, SwirlTextInputType } from "./components/swirl-text-input/swirl-text-input";
@@ -155,11 +155,11 @@ export { SwirlStackAlign, SwirlStackJustify, SwirlStackOrientation, SwirlStackSp
 export { SwirlStatusIndicatorIntent } from "./components/swirl-status-indicator/swirl-status-indicator";
 export { SwirlSwitchLabelPosition } from "./components/swirl-switch/swirl-switch";
 export { SwirlSymbolSize } from "./components/swirl-symbol/swirl-symbol.types";
+export { SwirlTabBarJustify as SwirlTabBarJustify1, SwirlTabBarPadding as SwirlTabBarPadding1, SwirlTabBarTabBadge, SwirlTabBarVariant as SwirlTabBarVariant1 } from "./components/swirl-tab-bar/swirl-tab-bar";
 export { SwirlTabPadding } from "./components/swirl-tab/swirl-tab";
 export { SwirlTabBarJustify, SwirlTabBarPadding, SwirlTabBarTab, SwirlTabBarVariant } from "./components/swirl-tab-bar/swirl-tab-bar";
 export { SwirlTableDropRowEvent } from "./components/swirl-table/swirl-table";
 export { SwirlTableColumnSort, SwirlTableColumnVariant } from "./components/swirl-table-column/swirl-table-column";
-export { SwirlTabBarJustify as SwirlTabBarJustify1, SwirlTabBarPadding as SwirlTabBarPadding1, SwirlTabBarVariant as SwirlTabBarVariant1 } from "./components/swirl-tab-bar/swirl-tab-bar";
 export { SwirlTagIconPosition, SwirlTagIntent, SwirlTagSize, SwirlTagVariant } from "./components/swirl-tag/swirl-tag";
 export { SwirlTextAlign, SwirlTextColor, SwirlTextFontFamily, SwirlTextFontStyle, SwirlTextSize, SwirlTextTruncateDirection, SwirlTextWeight, SwirlTextWhiteSpace } from "./components/swirl-text/swirl-text";
 export { SwirlTextInputFontSize, SwirlTextInputMode as SwirlTextInputMode1, SwirlTextInputType } from "./components/swirl-text-input/swirl-text-input";
@@ -5339,6 +5339,7 @@ export namespace Components {
     }
     interface SwirlTab {
         "active"?: boolean;
+        "badge"?: SwirlTabBarTabBadge;
         "icon"?: string;
         "label": string;
         /**
@@ -15700,6 +15701,7 @@ declare namespace LocalJSX {
     }
     interface SwirlTab {
         "active"?: boolean;
+        "badge"?: SwirlTabBarTabBadge;
         "icon"?: string;
         "label": string;
         /**

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.css
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.css
@@ -186,5 +186,5 @@
 }
 
 .tab-bar__tab-badge {
-  padding-left: var(--s-space-4);
+  padding-left: var(--s-space-6);
 }

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.css
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.css
@@ -150,6 +150,11 @@
     & .tab-bar__tab-suffix {
       color: var(--s-text-subdued);
     }
+
+    /* the badge sits inline on a pill, so it needs no border to separate it from its surroundings */
+    & .tab-bar__tab-badge {
+      --swirl-badge-border-color: transparent;
+    }
   }
 
   @media (--from-desktop-without-touch) {
@@ -178,4 +183,8 @@
 .tab-bar__tab-suffix {
   color: var(--s-interactive-neutral-default);
   font-weight: var(--s-font-weight-normal);
+}
+
+.tab-bar__tab-badge {
+  padding-left: var(--s-space-4);
 }

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.css
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.css
@@ -186,5 +186,5 @@
 }
 
 .tab-bar__tab-badge {
-  padding-left: var(--s-space-6);
+  padding-left: calc(var(--s-space-4) + var(--s-space-2));
 }

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
@@ -73,7 +73,8 @@ second.
 In the `pill` variant, no intent color has usable contrast against the active
 pill's filled primary background — `info` in particular resolves to the same
 color as the pill, leaving nothing visible. On the active pill the dot therefore
-falls back to `critical`, which reads against it like a notification indicator.
+falls back to `neutral`, which stays legible there. Inactive pills keep the
+requested `intent`.
 
 <Canvas of={Stories.WithPillVariant}></Canvas>
 

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
@@ -33,6 +33,7 @@ implement your own tab handling.
     },
     {
       active: true,
+      badge: { intent: "info", label: "Batches running" },
       icon: &apos;<swirl-icon glyph="emoji-mood" size="20"></swirl-icon>&apos;,
       id: "tab2",
       label: "Another Tab",
@@ -48,11 +49,39 @@ implement your own tab handling.
 ></swirl-tab-bar>`}
 />
 
+## Status badges
+
+A tab can render a status badge after its label — a dot that flags the tab as
+needing attention, for example because background work is running. The badge
+delegates to [SwirlBadge](?path=/docs/components-swirlbadge--docs) and is styled
+from design tokens; the only thing configurable is `intent`, which sets the dot
+color and defaults to `info`.
+
+`label` is required. The dot has no text, so the label is not shown, but it is
+announced as part of the tab's accessible name — that is how a screen reader user
+learns _why_ the tab is marked.
+
+<Source code={`badge: { intent: "info", label: "Batches running" }`} />
+
+A counted badge is not supported yet. For a number next to a tab label, use
+`suffix` — muted text that reads as part of the label. The [Usage](#usage)
+example above shows both: `suffix` on the first and second tabs, a badge on the
+second.
+
+## Pill variant
+
+In the `pill` variant, no intent color has usable contrast against the active
+pill's filled primary background — `info` in particular resolves to the same
+color as the pill, leaving nothing visible. On the active pill the dot therefore
+falls back to `critical`, which reads against it like a notification indicator.
+
+<Canvas of={Stories.WithPillVariant}></Canvas>
+
 ## Related components
 
 - **[swirl-tabs](?path=/docs/components-swirltabs--docs)** (parent) — Tab
   container; `swirl-tab-bar` is typically used inside `swirl-tabs` to render the
-  tab strip.
+  tab bar.
 - **[swirl-tab](?path=/docs/components-swirltab--docs)** (sibling) — Tab panels;
   use alongside `swirl-tab-bar` when building a tabbed UI.
 

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
@@ -58,8 +58,8 @@ from design tokens; the only thing configurable is `intent`, which sets the dot
 color and defaults to `info`.
 
 `label` is required. The dot has no text, so the label is not shown, but it is
-announced as part of the tab's accessible name — that is how a screen reader user
-learns _why_ the tab is marked.
+announced as part of the tab's accessible name — that is how a screen reader
+user learns _why_ the tab is marked.
 
 <Source code={`badge: { intent: "info", label: "Batches running" }`} />
 
@@ -74,9 +74,8 @@ In the `pill` variant, no intent color has usable contrast against the active
 pill's filled primary background — `info` in particular resolves to the same
 color as the pill, leaving nothing visible. On the active pill the dot therefore
 falls back to `neutral`, which stays legible there. Inactive pills keep the
-requested `intent`.
-
-<Canvas of={Stories.WithPillVariant}></Canvas>
+requested `intent`. Switch `variant` to `pill` on the [Usage](#usage) example to
+preview this.
 
 ## Related components
 

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.mdx
@@ -70,12 +70,10 @@ second.
 
 ## Pill variant
 
-In the `pill` variant, no intent color has usable contrast against the active
-pill's filled primary background — `info` in particular resolves to the same
-color as the pill, leaving nothing visible. On the active pill the dot therefore
-falls back to `neutral`, which stays legible there. Inactive pills keep the
-requested `intent`. Switch `variant` to `pill` on the [Usage](#usage) example to
-preview this.
+On an active pill, some intent colors — especially `info` — have little or no
+contrast against the filled primary background. Choose an intent that stays
+legible there; `neutral` is one option. Switch `variant` to `pill` on the
+[Usage](#usage) example to preview this.
 
 ## Related components
 

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.spec.tsx
@@ -174,7 +174,7 @@ describe("swirl-tab-bar", () => {
     expect(page.root.querySelector("#tab-tab3 swirl-badge")).toBeNull();
   });
 
-  it("renders tab status badges in the pill variant", async () => {
+  it("preserves the requested badge intent in the pill variant", async () => {
     const page = await newSpecPage({
       components: [SwirlTabBar],
       html: `<swirl-tab-bar label="Tabs" variant="pill"></swirl-tab-bar>`,
@@ -187,28 +187,12 @@ describe("swirl-tab-bar", () => {
         id: "tab1",
         label: "Tab #1",
       },
-      {
-        active: false,
-        badge: { intent: "info", label: "Syncing" },
-        id: "tab2",
-        label: "Tab #2",
-      },
     ];
 
     await page.waitForChanges();
 
-    expect(page.root.querySelector("#tab-tab1").className).toContain(
-      "tab-bar__tab--variant-pill"
-    );
-
-    // an `info` dot would be invisible against the active pill, so its intent
-    // is forced to `critical`. inactive pills keep the requested intent
     expect(
       page.root.querySelector("#tab-tab1 swirl-badge").getAttribute("intent")
-    ).toBe("neutral");
-
-    expect(
-      page.root.querySelector("#tab-tab2 swirl-badge").getAttribute("intent")
     ).toBe("info");
   });
 

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.spec.tsx
@@ -205,7 +205,7 @@ describe("swirl-tab-bar", () => {
     // is forced to `critical`. inactive pills keep the requested intent
     expect(
       page.root.querySelector("#tab-tab1 swirl-badge").getAttribute("intent")
-    ).toBe("critical");
+    ).toBe("neutral");
 
     expect(
       page.root.querySelector("#tab-tab2 swirl-badge").getAttribute("intent")

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.spec.tsx
@@ -106,6 +106,112 @@ describe("swirl-tab-bar", () => {
     expect(spy).toHaveBeenCalledTimes(4);
   });
 
+  it("renders tab status badges", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTabBar],
+      html: `<swirl-tab-bar label="Tabs"></swirl-tab-bar>`,
+    });
+
+    page.root.tabs = [
+      {
+        active: false,
+        badge: { intent: "info", label: "Batches running" },
+        id: "tab1",
+        label: "Tab #1",
+      },
+      {
+        active: true,
+        badge: { label: "Syncing" },
+        id: "tab2",
+        label: "Tab #2",
+      },
+      {
+        active: false,
+        id: "tab3",
+        label: "Tab #3",
+      },
+    ];
+
+    await page.waitForChanges();
+
+    expect(page.root).toEqualHtml(`
+      <swirl-tab-bar label="Tabs">
+        <div aria-label="Tabs" class="tab-bar tab-bar--justify-start tab-bar--variant-default" role="tablist">
+          <button aria-controls="tab1" aria-selected="false" class="tab-bar__tab tab-bar__tab--variant-default" id="tab-tab1" role="tab" tabindex="-1" type="button">
+            <span class="tab-bar__tab-label">
+              Tab #1
+              <swirl-badge class="tab-bar__tab-badge" intent="info" label="Batches running" size="xs" variant="dot"></swirl-badge>
+            </span>
+          </button>
+          <button aria-controls="tab2" aria-selected="true" class="tab-bar__tab tab-bar__tab--variant-default tab-bar__tab--active" id="tab-tab2" role="tab" tabindex="0" type="button">
+            <span class="tab-bar__tab-label">
+              Tab #2
+              <swirl-badge class="tab-bar__tab-badge" intent="info" label="Syncing" size="xs" variant="dot"></swirl-badge>
+            </span>
+          </button>
+          <button aria-controls="tab3" aria-selected="false" class="tab-bar__tab tab-bar__tab--variant-default" id="tab-tab3" role="tab" tabindex="-1" type="button">
+            <span class="tab-bar__tab-label">
+              Tab #3
+            </span>
+          </button>
+        </div>
+      </swirl-tab-bar>
+    `);
+
+    // the badge carries its own accessible label, which swirl-badge renders
+    // into a swirl-visually-hidden for the dot variant
+    expect(
+      page.root.querySelector("#tab-tab1 swirl-badge").getAttribute("label")
+    ).toBe("Batches running");
+
+    // an omitted intent falls back to "info" rather than swirl-badge's own
+    // "critical" default
+    expect(
+      page.root.querySelector("#tab-tab2 swirl-badge").getAttribute("intent")
+    ).toBe("info");
+
+    // tabs without a badge render none
+    expect(page.root.querySelector("#tab-tab3 swirl-badge")).toBeNull();
+  });
+
+  it("renders tab status badges in the pill variant", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTabBar],
+      html: `<swirl-tab-bar label="Tabs" variant="pill"></swirl-tab-bar>`,
+    });
+
+    page.root.tabs = [
+      {
+        active: true,
+        badge: { intent: "info", label: "Batches running" },
+        id: "tab1",
+        label: "Tab #1",
+      },
+      {
+        active: false,
+        badge: { intent: "info", label: "Syncing" },
+        id: "tab2",
+        label: "Tab #2",
+      },
+    ];
+
+    await page.waitForChanges();
+
+    expect(page.root.querySelector("#tab-tab1").className).toContain(
+      "tab-bar__tab--variant-pill"
+    );
+
+    // an `info` dot would be invisible against the active pill, so its intent
+    // is forced to `critical`. inactive pills keep the requested intent
+    expect(
+      page.root.querySelector("#tab-tab1 swirl-badge").getAttribute("intent")
+    ).toBe("critical");
+
+    expect(
+      page.root.querySelector("#tab-tab2 swirl-badge").getAttribute("intent")
+    ).toBe("info");
+  });
+
   it("wraps tabs with tooltips in swirl-tooltip", async () => {
     const page = await newSpecPage({
       components: [SwirlTabBar, SwirlTooltip],

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.stories.ts
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.stories.ts
@@ -1,4 +1,5 @@
 import { generateStoryElement } from "../../utils";
+import { SwirlTabBarTab } from "./swirl-tab-bar";
 import Docs from "./swirl-tab-bar.mdx";
 
 export default {
@@ -18,29 +19,44 @@ const Template = (args) => {
   return element;
 };
 
+// the badge sits on the active tab so the pill variant story shows the
+// combination where the intent color has no contrast and has to be adjusted
+const tabs: SwirlTabBarTab[] = [
+  {
+    active: false,
+    id: "tab1",
+    label: "A Tab",
+    suffix: "2",
+    tooltip: "With a tooltip",
+  },
+  {
+    active: true,
+    badge: {
+      intent: "info",
+      label: "Batches running",
+    },
+    icon: '<swirl-icon glyph="emoji-mood" size="20"></swirl-icon>',
+    id: "tab2",
+    label: "Another Tab",
+    suffix: "12",
+  },
+  {
+    active: false,
+    icon: '<swirl-icon glyph="emoji-satisfied" size="20"></swirl-icon>',
+    id: "tab3",
+    label: "Yet Another Tab",
+  },
+];
+
 export const SwirlTabBar = Template.bind({});
 
 SwirlTabBar.args = {
-  tabs: [
-    {
-      active: false,
-      id: "tab1",
-      label: "A Tab",
-      suffix: "2",
-      tooltip: "With a tooltip",
-    },
-    {
-      active: true,
-      icon: '<swirl-icon glyph="emoji-mood" size="20"></swirl-icon>',
-      id: "tab2",
-      label: "Another Tab",
-      suffix: "12",
-    },
-    {
-      active: false,
-      icon: '<swirl-icon glyph="emoji-satisfied" size="20"></swirl-icon>',
-      id: "tab3",
-      label: "Yet Another Tab",
-    },
-  ],
+  tabs,
+};
+
+export const WithPillVariant = Template.bind({});
+
+WithPillVariant.args = {
+  tabs,
+  variant: "pill",
 };

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.stories.ts
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.stories.ts
@@ -19,8 +19,6 @@ const Template = (args) => {
   return element;
 };
 
-// the badge sits on the active tab so switching variant to pill shows the
-// combination where the intent color has no contrast and has to be adjusted
 const tabs: SwirlTabBarTab[] = [
   {
     active: false,

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.stories.ts
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.stories.ts
@@ -19,7 +19,7 @@ const Template = (args) => {
   return element;
 };
 
-// the badge sits on the active tab so the pill variant story shows the
+// the badge sits on the active tab so switching variant to pill shows the
 // combination where the intent color has no contrast and has to be adjusted
 const tabs: SwirlTabBarTab[] = [
   {
@@ -52,11 +52,4 @@ export const SwirlTabBar = Template.bind({});
 
 SwirlTabBar.args = {
   tabs,
-};
-
-export const WithPillVariant = Template.bind({});
-
-WithPillVariant.args = {
-  tabs,
-  variant: "pill",
 };

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.tsx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.tsx
@@ -151,15 +151,6 @@ export class SwirlTabBar {
               "tab-bar__tab-label--variant-pill": this.variant === "pill",
             });
 
-            // a dot has no text, so its intent color is the only thing carrying
-            // its meaning — and no intent reads against the active pill's filled
-            // primary background, `info` resolving to the pill color itself and
-            // leaving nothing visible. `neutral` is legible there instead.
-            const badgeIntent: SwirlBadgeIntent =
-              this.variant === "pill" && tab.active
-                ? "neutral"
-                : tab.badge?.intent ?? "info";
-
             const tabButton = (
               <button
                 aria-controls={this.disableTabSemantics ? undefined : tab.id}
@@ -193,7 +184,7 @@ export class SwirlTabBar {
                   {tab.badge && (
                     <swirl-badge
                       class="tab-bar__tab-badge"
-                      intent={badgeIntent}
+                      intent={tab.badge.intent ?? "info"}
                       label={tab.badge.label}
                       size="xs"
                       variant="dot"

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.tsx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.tsx
@@ -152,9 +152,9 @@ export class SwirlTabBar {
             });
 
             // a dot has no text, so its intent color is the only thing carrying
-            // its meaning — and on the filled pill `info` resolves to the pill
-            // color itself, leaving nothing visible. `critical` reads against it
-            // behaving like a notification indicator.
+            // its meaning — and no intent reads against the active pill's filled
+            // primary background, `info` resolving to the pill color itself and
+            // leaving nothing visible. `neutral` is legible there instead.
             const badgeIntent: SwirlBadgeIntent =
               this.variant === "pill" && tab.active
                 ? "neutral"

--- a/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.tsx
+++ b/packages/swirl-components/src/components/swirl-tab-bar/swirl-tab-bar.tsx
@@ -9,9 +9,21 @@ import {
 } from "@stencil/core";
 import classnames from "classnames";
 import { getCircularArrayIndex } from "../../utils";
+import { SwirlBadgeIntent } from "../swirl-badge/swirl-badge";
+
+/**
+ * A status badge on a tab. Renders as a dot; `label` is not shown but is
+ * announced as part of the tab's accessible name. A counted badge is not
+ * supported yet.
+ */
+export type SwirlTabBarTabBadge = {
+  intent?: SwirlBadgeIntent;
+  label: string;
+};
 
 export type SwirlTabBarTab = {
   active?: boolean;
+  badge?: SwirlTabBarTabBadge;
   icon?: string;
   id: string;
   label: string;
@@ -139,6 +151,15 @@ export class SwirlTabBar {
               "tab-bar__tab-label--variant-pill": this.variant === "pill",
             });
 
+            // a dot has no text, so its intent color is the only thing carrying
+            // its meaning — and on the filled pill `info` resolves to the pill
+            // color itself, leaving nothing visible. `critical` reads against it
+            // behaving like a notification indicator.
+            const badgeIntent: SwirlBadgeIntent =
+              this.variant === "pill" && tab.active
+                ? "neutral"
+                : tab.badge?.intent ?? "info";
+
             const tabButton = (
               <button
                 aria-controls={this.disableTabSemantics ? undefined : tab.id}
@@ -168,6 +189,15 @@ export class SwirlTabBar {
                   {tab.label}
                   {tab.suffix && (
                     <span class="tab-bar__tab-suffix">{tab.suffix}</span>
+                  )}
+                  {tab.badge && (
+                    <swirl-badge
+                      class="tab-bar__tab-badge"
+                      intent={badgeIntent}
+                      label={tab.badge.label}
+                      size="xs"
+                      variant="dot"
+                    />
                   )}
                 </span>
               </button>

--- a/packages/swirl-components/src/components/swirl-tab/swirl-tab.mdx
+++ b/packages/swirl-components/src/components/swirl-tab/swirl-tab.mdx
@@ -25,6 +25,27 @@ The SwirlTab component is used to display a tab panel inside the
 </swirl-tab>`}
 />
 
+## Tab item props
+
+`swirl-tab` renders only the tab panel. The `badge`, `icon`, `label` and
+`tooltip` props describe the corresponding tab bar item, and are forwarded by
+[SwirlTabs](?path=/docs/components-swirltabs--docs) to
+[SwirlTabBar](?path=/docs/components-swirltabbar--docs).
+
+`badge` renders a status badge — a dot — after the tab label. Because it is an
+object it has to be set as a property, not an attribute:
+
+<Source
+  code={`document.querySelector("[tab-id='tab-id']").badge = {
+    intent: "info",
+    label: "Batches running",
+};`}
+/>
+
+`swirl-tabs` reads these props when it builds the tab bar, which happens on load
+and on tab activation, so set them before mount. Changing one at runtime does not
+refresh the tab bar until the next activation.
+
 ## Related components
 
 - **[swirl-tabs](?path=/docs/components-swirltabs--docs)** (parent) — Tab

--- a/packages/swirl-components/src/components/swirl-tab/swirl-tab.mdx
+++ b/packages/swirl-components/src/components/swirl-tab/swirl-tab.mdx
@@ -32,19 +32,9 @@ The SwirlTab component is used to display a tab panel inside the
 [SwirlTabs](?path=/docs/components-swirltabs--docs) to
 [SwirlTabBar](?path=/docs/components-swirltabbar--docs).
 
-`badge` renders a status badge — a dot — after the tab label. Because it is an
-object it has to be set as a property, not an attribute:
-
-<Source
-  code={`document.querySelector("[tab-id='tab-id']").badge = {
-    intent: "info",
-    label: "Batches running",
-};`}
-/>
-
 `swirl-tabs` reads these props when it builds the tab bar, which happens on load
-and on tab activation, so set them before mount. Changing one at runtime does not
-refresh the tab bar until the next activation.
+and on tab activation, so set them before mount. Changing one at runtime does
+not refresh the tab bar until the next activation.
 
 ## Related components
 

--- a/packages/swirl-components/src/components/swirl-tab/swirl-tab.tsx
+++ b/packages/swirl-components/src/components/swirl-tab/swirl-tab.tsx
@@ -1,5 +1,6 @@
 import { Component, h, Host, Prop } from "@stencil/core";
 import classnames from "classnames";
+import { SwirlTabBarTabBadge } from "../swirl-tab-bar/swirl-tab-bar";
 
 export type SwirlTabPadding = "0" | "2" | "4" | "8" | "12" | "16" | "20" | "24";
 
@@ -10,6 +11,9 @@ export type SwirlTabPadding = "0" | "2" | "4" | "8" | "12" | "16" | "20" | "24";
 })
 export class SwirlTab {
   @Prop() active?: boolean;
+  // `badge`, `icon`, `label` and `tooltip` style the tabs
+  // swirl-tabs copies them into the tab bar, re-reading them only on tab click.
+  @Prop() badge?: SwirlTabBarTabBadge;
   @Prop() icon?: string;
   @Prop() label!: string;
   @Prop() padding?: SwirlTabPadding = "8";

--- a/packages/swirl-components/src/components/swirl-tab/swirl-tab.tsx
+++ b/packages/swirl-components/src/components/swirl-tab/swirl-tab.tsx
@@ -11,8 +11,6 @@ export type SwirlTabPadding = "0" | "2" | "4" | "8" | "12" | "16" | "20" | "24";
 })
 export class SwirlTab {
   @Prop() active?: boolean;
-  // `badge`, `icon`, `label` and `tooltip` style the tabs
-  // swirl-tabs copies them into the tab bar, re-reading them only on tab click.
   @Prop() badge?: SwirlTabBarTabBadge;
   @Prop() icon?: string;
   @Prop() label!: string;

--- a/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.mdx
+++ b/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.mdx
@@ -31,10 +31,40 @@ panels.
 </swirl-tabs>`}
 />
 
+## Status badges
+
+A `swirl-tab` can carry a `badge` — a dot that flags the tab as needing
+attention — which `swirl-tabs` forwards to the tab bar, where it is rendered
+after the tab label. Its `label` is required and is announced as part of the
+tab's accessible name. See
+[SwirlTabBar](?path=/docs/components-swirltabbar--docs#status-badges).
+
+Because `badge` is an object it has to be set as a property, not an attribute,
+and it has to be set before mount — `swirl-tabs` reads it when it builds the tab
+bar.
+
+<Canvas of={Stories.StatusBadges}></Canvas>
+
+<Source
+  code={`<swirl-tabs initial-tab="tab-1" label="Tabs">
+    <swirl-tab label="Users" tab-id="tab-1"><swirl-text>Users</swirl-text></swirl-tab>
+    <swirl-tab label="Invite code batches" tab-id="tab-2"><swirl-text>Invite code batches</swirl-text></swirl-tab>
+    <swirl-tab label="Groups" tab-id="tab-3"><swirl-text>Groups</swirl-text></swirl-tab>
+</swirl-tabs>
+
+<script>
+    document.querySelector("[tab-id='tab-2']").badge = {
+        intent: "info",
+        label: "Batches running",
+    };
+</script>`}
+
+/>
+
 ## Related components
 
 - **[swirl-tab-bar](?path=/docs/components-swirltabbar--docs)** (child) —
-  Renders the tab strip; use inside `swirl-tabs`.
+  Renders the tab bar; use inside `swirl-tabs`.
 - **[swirl-tab](?path=/docs/components-swirltab--docs)** (child) — Tab panels;
   use as direct children of `swirl-tabs`.
 

--- a/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.spec.tsx
@@ -83,6 +83,49 @@ describe("swirl-tabs", () => {
     expect(tabs.find((tab) => tab.active).tabId).toBe("tab-2");
   });
 
+  it("forwards tab badges to the tab bar", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTabs, SwirlTab, SwirlTabBar],
+      html: `
+        <swirl-tabs label="Tabs">
+          <swirl-tab label="Tab #1" tab-id="tab-1">Tab 1</swirl-tab>
+          <swirl-tab label="Tab #2" tab-id="tab-2">Tab 2</swirl-tab>
+        </swirl-tabs>
+      `,
+    });
+
+    expect(page.root.querySelector("#tab-tab-2 swirl-badge")).toBeNull();
+
+    page.root.querySelector<HTMLSwirlTabElement>(
+      "swirl-tab[tab-id='tab-2']"
+    ).badge = {
+      intent: "info",
+      label: "Batches running",
+    };
+
+    // the tab bar renders from a snapshot taken on load and on activation, so
+    // the badge reaches it with the next activation
+    await page.rootInstance.activateTab("tab-2");
+    await page.waitForChanges();
+
+    const badge = page.root.querySelector("#tab-tab-2 swirl-badge");
+
+    expect(badge).not.toBeNull();
+    expect(badge.getAttribute("variant")).toBe("dot");
+    expect(badge.getAttribute("intent")).toBe("info");
+    expect(badge.getAttribute("label")).toBe("Batches running");
+
+    // and clearing it removes the badge again
+    page.root.querySelector<HTMLSwirlTabElement>(
+      "swirl-tab[tab-id='tab-2']"
+    ).badge = undefined;
+
+    await page.rootInstance.activateTab("tab-1");
+    await page.waitForChanges();
+
+    expect(page.root.querySelector("#tab-tab-2 swirl-badge")).toBeNull();
+  });
+
   it("activates tabs via keyboard", async () => {
     const page = await newSpecPage({
       components: [SwirlTabs, SwirlTab, SwirlTabBar],

--- a/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.stories.ts
+++ b/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.stories.ts
@@ -30,3 +30,28 @@ SwirlTabs.args = {
   initialTab: "tab-2",
   label: "Tabs",
 };
+
+const StatusBadgesTemplate = (args) => {
+  const element = generateStoryElement("swirl-tabs", args);
+
+  element.innerHTML = `
+    <swirl-tab label="Users" tab-id="tab-1"><swirl-text>Users</swirl-text></swirl-tab>
+    <swirl-tab label="Invite code batches" tab-id="tab-2"><swirl-text>Invite code batches</swirl-text></swirl-tab>
+    <swirl-tab label="Groups" tab-id="tab-3"><swirl-text>Groups</swirl-text></swirl-tab>
+  `;
+
+  // badge is an object, so it has to be set as a property
+  element.querySelector<HTMLSwirlTabElement>("[tab-id='tab-2']").badge = {
+    intent: "info",
+    label: "Batches running",
+  };
+
+  return element;
+};
+
+export const StatusBadges = StatusBadgesTemplate.bind({});
+
+StatusBadges.args = {
+  initialTab: "tab-1",
+  label: "Tabs",
+};

--- a/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.tsx
+++ b/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.tsx
@@ -117,9 +117,6 @@ export class SwirlTabs {
     );
   }
 
-  // snapshots the tab item props of every swirl-tab into the state the tab bar
-  // renders from. Only called on load and on activation, so a swirl-tab prop
-  // changed at runtime is not picked up until the next activation.
   private updateTabBarTabs() {
     this.tabBarTabs = this.tabs.map((tab) => ({
       active: this.activeTab === tab.tabId,

--- a/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.tsx
+++ b/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.tsx
@@ -117,6 +117,8 @@ export class SwirlTabs {
     );
   }
 
+  // only runs on load and on activation
+  // a prop change at runtime is not picked up until the next tab click
   private updateTabBarTabs() {
     this.tabBarTabs = this.tabs.map((tab) => ({
       active: this.activeTab === tab.tabId,

--- a/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.tsx
+++ b/packages/swirl-components/src/components/swirl-tabs/swirl-tabs.tsx
@@ -117,9 +117,13 @@ export class SwirlTabs {
     );
   }
 
+  // snapshots the tab item props of every swirl-tab into the state the tab bar
+  // renders from. Only called on load and on activation, so a swirl-tab prop
+  // changed at runtime is not picked up until the next activation.
   private updateTabBarTabs() {
     this.tabBarTabs = this.tabs.map((tab) => ({
       active: this.activeTab === tab.tabId,
+      badge: tab.badge,
       icon: tab.icon,
       id: tab.tabId,
       label: tab.label,


### PR DESCRIPTION
## Summary


- [Ticket](https://linear.app/flip/issue/ACT-4193/swirl-support-a-status-badge-on-swirl-tab-bar-tabs)
- [Design](https://www.figma.com/design/LWIJbG2TxWy86KMsupxTl2/Bulk-Invite-Code-Generation?node-id=2133-88125&m=dev)
