### PR TITLE
Add interactive prop to swirl-tag

### DIFF
--- a/.changeset/spotty-buttons-shake.md
+++ b/.changeset/spotty-buttons-shake.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": minor
+---
+
+feat(swirl-tag): add interactive prop

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -61823,6 +61823,14 @@
               "fieldName": "intent"
             },
             {
+              "name": "interactive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "interactive"
+            },
+            {
               "name": "label",
               "type": {
                 "text": "string"
@@ -61931,6 +61939,16 @@
             },
             {
               "kind": "field",
+              "name": "interactive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "interactive"
+            },
+            {
+              "kind": "field",
               "name": "label",
               "type": {
                 "text": "string"
@@ -61990,6 +62008,18 @@
           "events": [
             {
               "name": "remove",
+              "type": {
+                "text": "CustomEvent<MouseEvent>",
+                "references": [
+                  {
+                    "name": "MouseEvent",
+                    "package": "global:"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "tagClick",
               "type": {
                 "text": "CustomEvent<MouseEvent>",
                 "references": [

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -5460,6 +5460,10 @@ export namespace Components {
           * @default "default"
          */
         "intent"?: SwirlTagIntent;
+        /**
+          * @default false
+         */
+        "interactive"?: boolean;
         "label": string;
         "removable"?: boolean;
         /**
@@ -9901,6 +9905,7 @@ declare global {
     };
     interface HTMLSwirlTagElementEventMap {
         "remove": MouseEvent;
+        "tagClick": MouseEvent;
     }
     interface HTMLSwirlTagElement extends Components.SwirlTag, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSwirlTagElementEventMap>(type: K, listener: (this: HTMLSwirlTagElement, ev: SwirlTagCustomEvent<HTMLSwirlTagElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -15833,8 +15838,13 @@ declare namespace LocalJSX {
           * @default "default"
          */
         "intent"?: SwirlTagIntent;
+        /**
+          * @default false
+         */
+        "interactive"?: boolean;
         "label": string;
         "onRemove"?: (event: SwirlTagCustomEvent<MouseEvent>) => void;
+        "onTagClick"?: (event: SwirlTagCustomEvent<MouseEvent>) => void;
         "removable"?: boolean;
         /**
           * @default "Remove"
@@ -18954,6 +18964,7 @@ declare namespace LocalJSX {
         "icon": string;
         "iconPosition": SwirlTagIconPosition;
         "intent": SwirlTagIntent;
+        "interactive": boolean;
         "label": string;
         "removable": boolean;
         "bordered": boolean;

--- a/packages/swirl-components/src/components/swirl-tag/swirl-tag.css
+++ b/packages/swirl-components/src/components/swirl-tag/swirl-tag.css
@@ -202,6 +202,39 @@
   }
 }
 
+.tag--interactive {
+  position: relative;
+  margin: 0;
+  font-family: inherit;
+  text-align: start;
+  cursor: pointer;
+  appearance: none;
+
+  &::after {
+    position: absolute;
+    border-radius: inherit;
+    content: "";
+    inset: calc(-1 * var(--s-border-width-default));
+    pointer-events: none;
+  }
+
+  &:hover::after {
+    background-color: var(--s-state-hovered);
+  }
+
+  &:active::after {
+    background-color: var(--s-state-pressed);
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline-color: var(--s-focus-default);
+  }
+}
+
 .tag__icon {
   display: inline-flex;
   margin-right: var(--s-space-4);

--- a/packages/swirl-components/src/components/swirl-tag/swirl-tag.css
+++ b/packages/swirl-components/src/components/swirl-tag/swirl-tag.css
@@ -204,11 +204,8 @@
 
 .tag--interactive {
   position: relative;
-  margin: 0;
   font-family: inherit;
-  text-align: start;
   cursor: pointer;
-  appearance: none;
 
   &::after {
     position: absolute;

--- a/packages/swirl-components/src/components/swirl-tag/swirl-tag.mdx
+++ b/packages/swirl-components/src/components/swirl-tag/swirl-tag.mdx
@@ -20,6 +20,17 @@ The SwirlTag component is used to label or categorize items using keywords.
 
 <Source code={`<swirl-tag label="Label" removable></swirl-tag>`} />
 
+## Interactive tags
+
+Use the `interactive` prop to make the whole tag clickable. It renders the tag
+as a native button, emits a `tagClick` event, and overlays the tag with a
+hovered and pressed state that works with every intent and variant.
+
+<Source code={`<swirl-tag label="Label" interactive></swirl-tag>`} />
+
+Avoid combining `interactive` with `removable`: the removal button would be
+nested inside the interactive tag's button, which is invalid HTML.
+
 ## Related components
 
 No related components.
@@ -30,12 +41,12 @@ No related components.
 
 | ARIA            | Usage                                                                            |
 | --------------- | -------------------------------------------------------------------------------- |
-| `role="button"` | Removable tags use a native button.                                              |
+| `role="button"` | Interactive and removable tags use a native button.                              |
 | `aria-label`    | The removal button gets an accessible label via the `removal-button-label` prop. |
 
 ### Keyboard
 
-| Key              | Action                        |
-| ---------------- | ----------------------------- |
-| <kbd>ENTER</kbd> | Activates the removal button. |
-| <kbd>SPACE</kbd> | Activates the removal button. |
+| Key              | Action                                               |
+| ---------------- | ---------------------------------------------------- |
+| <kbd>ENTER</kbd> | Activates the interactive tag or the removal button. |
+| <kbd>SPACE</kbd> | Activates the interactive tag or the removal button. |

--- a/packages/swirl-components/src/components/swirl-tag/swirl-tag.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-tag/swirl-tag.spec.tsx
@@ -85,6 +85,40 @@ describe("swirl-tag", () => {
     `);
   });
 
+  it("renders as button when interactive", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTag],
+      html: `<swirl-tag interactive="true" intent="info" label="Label"></swirl-tag>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <swirl-tag interactive="true" intent="info" label="Label">
+        <mock:shadow-root>
+          <button class="tag tag--icon-position-start tag--intent-info tag--interactive tag--size-m tag--variant-default" part="tag" type="button">
+            <span class="tag__label">
+              Label
+            </span>
+          </button>
+        </mock:shadow-root>
+      </swirl-tag>
+    `);
+  });
+
+  it("emits tagClick when interactive", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTag],
+      html: `<swirl-tag interactive="true" label="Label"></swirl-tag>`,
+    });
+
+    const button = page.root.shadowRoot.querySelector("button");
+    const spy = jest.fn();
+
+    page.root.addEventListener("tagClick", spy);
+    button.click();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
   it("can be removed", async () => {
     const page = await newSpecPage({
       components: [SwirlTag],

--- a/packages/swirl-components/src/components/swirl-tag/swirl-tag.tsx
+++ b/packages/swirl-components/src/components/swirl-tag/swirl-tag.tsx
@@ -36,6 +36,7 @@ export class SwirlTag {
   @Prop() icon?: string;
   @Prop() iconPosition: SwirlTagIconPosition = "start";
   @Prop() intent?: SwirlTagIntent = "default";
+  @Prop() interactive?: boolean = false;
   @Prop() label!: string;
   @Prop() removable?: boolean;
   @Prop() bordered?: boolean;
@@ -44,6 +45,7 @@ export class SwirlTag {
   @Prop({ mutable: true }) variant?: SwirlTagVariant = "default";
 
   @Event({ eventName: "remove" }) removeTag?: EventEmitter<MouseEvent>;
+  @Event() tagClick: EventEmitter<MouseEvent>;
 
   private iconEl: HTMLElement;
 
@@ -78,19 +80,36 @@ export class SwirlTag {
     this.removeTag?.emit(event);
   };
 
+  private onClick = (event: MouseEvent) => {
+    this.tagClick.emit(event);
+  };
+
   render() {
+    const Tag = this.interactive ? "button" : "span";
+
     const className = classnames(
       "tag",
       `tag--icon-position-${this.iconPosition}`,
       `tag--intent-${this.intent}`,
       `tag--size-${this.size}`,
       `tag--variant-${this.variant}`,
-      { "tag--hide-label": this.hideLabel }
+      {
+        "tag--hide-label": this.hideLabel,
+        "tag--interactive": this.interactive,
+      }
     );
 
     return (
       <Host>
-        <span class={className} part="tag">
+        <Tag
+          class={className}
+          onClick={this.interactive ? this.onClick : undefined}
+          part="tag"
+          tabIndex={
+            this.interactive && this.el.ariaHidden === "true" ? -1 : undefined
+          }
+          type={this.interactive ? "button" : undefined}
+        >
           {this.icon && (
             <span
               class="tag__icon"
@@ -114,7 +133,7 @@ export class SwirlTag {
               <swirl-icon-close size={16}></swirl-icon-close>
             </button>
           )}
-        </span>
+        </Tag>
       </Host>
     );
   }

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -26094,6 +26094,10 @@
           ]
         },
         {
+          "name": "interactive",
+          "description": ""
+        },
+        {
           "name": "label",
           "description": ""
         },


### PR DESCRIPTION
## Summary

- [Ticket](https://linear.app/flip/issue/FUS-885/update-swirl-tag-to-have-an-interactive-property)
