### PR TITLE
Add mobileBottomSheet prop to swirl-popover

### DIFF
--- a/.changeset/swirl-popover-mobile-bottom-sheet.md
+++ b/.changeset/swirl-popover-mobile-bottom-sheet.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Add `mobileBottomSheet` prop to swirl-popover

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -47523,6 +47523,14 @@
               "fieldName": "maxHeight"
             },
             {
+              "name": "mobile-bottom-sheet",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "fieldName": "mobileBottomSheet"
+            },
+            {
               "name": "offset",
               "type": {
                 "text": "number | number[]"
@@ -47695,6 +47703,16 @@
               "default": "\"22rem\"",
               "readonly": true,
               "attribute": "max-height"
+            },
+            {
+              "kind": "field",
+              "name": "mobileBottomSheet",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "true",
+              "readonly": true,
+              "attribute": "mobile-bottom-sheet"
             },
             {
               "kind": "field",

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -4129,6 +4129,10 @@ export namespace Components {
          */
         "maxHeight"?: string;
         /**
+          * @default true
+         */
+        "mobileBottomSheet"?: boolean;
+        /**
           * @default 8
          */
         "offset"?: number | number[];
@@ -14506,6 +14510,10 @@ declare namespace LocalJSX {
          */
         "maxHeight"?: string;
         /**
+          * @default true
+         */
+        "mobileBottomSheet"?: boolean;
+        /**
           * @default 8
          */
         "offset"?: number | number[];
@@ -18309,6 +18317,7 @@ declare namespace LocalJSX {
         "fullscreenBottomSheet": boolean;
         "label": string;
         "maxHeight": string;
+        "mobileBottomSheet": boolean;
         "offset": number | number[];
         "padded": boolean;
         "popoverId": string;

--- a/packages/swirl-components/src/components/swirl-menu/swirl-menu.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-menu/swirl-menu.spec.tsx
@@ -85,7 +85,7 @@ describe("swirl-menu", () => {
         </swirl-popover-trigger>
         <swirl-popover id="menu" label="Menu">
           <template shadowrootmode="open">
-            <div class="popover popover--animation-scale-in-xy popover--inactive popover--padded popover--placement-undefined popover--translucent" popover="manual">
+            <div class="popover popover--animation-scale-in-xy popover--inactive popover--mobile-bottom-sheet popover--padded popover--placement-undefined popover--translucent" popover="manual">
               <div aria-hidden="true" aria-label="Menu" class="popover__content" part="popover__content" role="dialog" tabindex="-1" style="--swirl-popover-border-radius: var(--s-border-radius-base);">
                 <span class="popover__handle"></span>
                 <div class="popover__scroll-container" part="popover__scroll-container">

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.css
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.css
@@ -30,11 +30,7 @@
   }
 
   & .popover__content {
-    animation: 0.15s popover-slide-in;
-
-    @media (--from-tablet) {
-      animation: 0.15s popover-fade-scale-in-xy;
-    }
+    animation: 0.15s popover-fade-scale-in-xy;
 
     @media (prefers-reduced-motion) {
       animation: none;
@@ -52,11 +48,7 @@
   }
 
   & .popover__content {
-    animation: 0.15s popover-slide-out forwards;
-
-    @media (--from-tablet) {
-      animation: 0.15s popover-fade-out forwards;
-    }
+    animation: 0.15s popover-fade-out forwards;
 
     @media (prefers-reduced-motion) {
       animation: none;
@@ -64,9 +56,197 @@
   }
 }
 
+.popover--animation-scale-in-y {
+  &.popover--active:not(.popover--closing) {
+    & .popover__content {
+      animation: 0.15s popover-fade-scale-in-y;
+
+      @media (prefers-reduced-motion) {
+        animation: none;
+      }
+    }
+  }
+}
+
+.popover--animation-fade-in {
+  &.popover--active:not(.popover--closing) {
+    & .popover__content {
+      animation: 0.15s popover-fade-in;
+
+      @media (prefers-reduced-motion) {
+        animation: none;
+      }
+    }
+  }
+}
+
 .popover--inactive {
   & .popover__content {
     display: none;
+  }
+}
+
+.popover--placement-bottom,
+.popover--placement-bottom-start,
+.popover--placement-right,
+.popover--placement-right-start {
+  .popover__content {
+    transform-origin: top left;
+  }
+}
+
+.popover--placement-bottom-end,
+.popover--placement-left,
+.popover--placement-left-start {
+  .popover__content {
+    transform-origin: top right;
+  }
+}
+
+.popover--placement-top,
+.popover--placement-top-start,
+.popover--placement-right-end {
+  .popover__content {
+    transform-origin: bottom left;
+  }
+}
+
+.popover--placement-top-end,
+.popover--placement-left-end {
+  .popover__content {
+    transform-origin: bottom right;
+  }
+}
+
+.popover--transparent {
+  & .popover__content {
+    background-color: transparent;
+    box-shadow: none;
+  }
+
+  & .popover__scroll-container {
+    padding: 0;
+  }
+}
+
+.popover__backdrop {
+  position: fixed;
+  z-index: 0;
+  display: none;
+  background-color: rgba(0, 0, 0, 0.2);
+  animation: 0.15s popover-backdrop-fade-in;
+  inset: 0;
+
+  @media (prefers-reduced-motion) {
+    animation: none;
+  }
+}
+
+.popover__content {
+  position: fixed;
+  z-index: 2;
+  overflow: hidden;
+  border-radius: var(
+    --swirl-popover-border-radius,
+    var(--s-border-radius-base)
+  );
+  max-width: 22.5rem;
+  background-color: var(--s-surface-overlay-default);
+  box-shadow: var(--s-shadow-level-2);
+}
+
+.popover__scroll-container {
+  overflow-x: hidden;
+  overflow-y: auto;
+  width: 100%;
+  max-height: 22rem;
+  overscroll-behavior: contain;
+}
+
+.popover--padded {
+  .popover__scroll-container {
+    padding: var(--s-space-4);
+  }
+}
+
+.popover__handle {
+  position: absolute;
+  top: var(--s-space-8);
+  left: 50%;
+  display: none;
+  width: 2.5rem;
+  height: 0.375rem;
+  border-radius: 0.1875rem;
+  background-color: var(--s-border-default);
+  transform: translatex(-50%);
+}
+
+.popover--mobile-bottom-sheet {
+  @media (--to-tablet) {
+    &.popover--active:not(.popover--closing) {
+      & .popover__content {
+        animation: 0.15s popover-slide-in;
+
+        @media (prefers-reduced-motion) {
+          animation: none;
+        }
+      }
+    }
+
+    &.popover--closing {
+      & .popover__content {
+        animation: 0.15s popover-slide-out forwards;
+
+        @media (prefers-reduced-motion) {
+          animation: none;
+        }
+      }
+    }
+
+    & .popover__backdrop {
+      display: block;
+    }
+
+    & .popover__content {
+      right: 0;
+      bottom: 0;
+      left: 0;
+      border-radius: var(--s-border-radius-xl) var(--s-border-radius-xl) 0 0;
+      max-width: none;
+      background-color: var(--s-surface-overlay-default);
+      box-shadow: none;
+    }
+
+    & .popover__scroll-container {
+      max-height: 90vh;
+      padding: var(--s-space-24) 0;
+    }
+
+    & .popover__handle {
+      display: block;
+    }
+  }
+}
+
+.popover--translucent {
+  & .popover__content {
+    background-color: transparent;
+    outline: var(--s-border-width-default) solid
+      var(--s-border-translucent-outline);
+
+    &:before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      background: var(--s-translucent-low-default);
+      backdrop-filter: blur(var(--s-blur-l));
+      border-radius: inherit;
+    }
+  }
+
+  & .popover__handle {
+    background-color: var(--s-border-on-translucent);
   }
 }
 
@@ -113,191 +293,6 @@
     & .popover__handle {
       display: none;
     }
-  }
-}
-
-.popover--animation-scale-in-y {
-  &.popover--active:not(.popover--closing) {
-    & .popover__content {
-      @media (--from-tablet) {
-        animation: 0.15s popover-fade-scale-in-y;
-      }
-
-      @media (prefers-reduced-motion) {
-        animation: none;
-      }
-    }
-  }
-}
-
-.popover--animation-fade-in {
-  &.popover--active:not(.popover--closing) {
-    & .popover__content {
-      @media (--from-tablet) {
-        animation: 0.15s popover-fade-in;
-      }
-
-      @media (prefers-reduced-motion) {
-        animation: none;
-      }
-    }
-  }
-}
-
-.popover--placement-bottom,
-.popover--placement-bottom-start,
-.popover--placement-right,
-.popover--placement-right-start {
-  .popover__content {
-    @media (--from-tablet) {
-      transform-origin: top left;
-    }
-  }
-}
-
-.popover--placement-bottom-end,
-.popover--placement-left,
-.popover--placement-left-start {
-  .popover__content {
-    @media (--from-tablet) {
-      transform-origin: top right;
-    }
-  }
-}
-
-.popover--placement-top,
-.popover--placement-top-start,
-.popover--placement-right-end {
-  .popover__content {
-    @media (--from-tablet) {
-      transform-origin: bottom left;
-    }
-  }
-}
-
-.popover--placement-top-end,
-.popover--placement-left-end {
-  .popover__content {
-    @media (--from-tablet) {
-      transform-origin: bottom right;
-    }
-  }
-}
-
-.popover--transparent {
-  & .popover__content {
-    @media (--from-tablet) {
-      background-color: transparent;
-      box-shadow: none;
-    }
-  }
-
-  & .popover__scroll-container {
-    @media (--from-tablet) {
-      padding: 0;
-    }
-  }
-}
-
-.popover--translucent {
-  & .popover__content {
-    background-color: transparent;
-    outline: var(--s-border-width-default) solid
-      var(--s-border-translucent-outline);
-
-    &:before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      z-index: -1;
-      background: var(--s-translucent-low-default);
-      backdrop-filter: blur(var(--s-blur-l));
-      border-radius: inherit;
-    }
-  }
-
-  & .popover__handle {
-    background-color: var(--s-border-on-translucent);
-  }
-}
-
-.popover__backdrop {
-  position: fixed;
-  z-index: 0;
-  background-color: rgba(0, 0, 0, 0.2);
-  animation: 0.15s popover-backdrop-fade-in;
-  inset: 0;
-
-  @media (prefers-reduced-motion) {
-    animation: none;
-  }
-
-  @media (--from-tablet) {
-    display: none;
-  }
-}
-
-.popover__content {
-  position: fixed;
-  z-index: 2;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  overflow: hidden;
-  border-top-left-radius: var(--s-border-radius-xl);
-  border-top-right-radius: var(--s-border-radius-xl);
-  background-color: var(--s-surface-overlay-default);
-
-  @media (--from-tablet) {
-    right: unset;
-    bottom: unset;
-    left: unset;
-    border-radius: var(
-      --swirl-popover-border-radius,
-      var(--s-border-radius-base)
-    );
-    max-width: 22.5rem;
-    animation: none;
-    box-shadow: var(--s-shadow-level-2);
-  }
-}
-
-.popover__scroll-container {
-  overflow-x: hidden;
-  overflow-y: auto;
-  width: 100%;
-  max-height: 90vh;
-  padding-top: var(--s-space-24);
-  padding-bottom: var(--s-space-24);
-  overscroll-behavior: contain;
-
-  @media (--from-tablet) {
-    max-height: 22rem;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
-}
-
-.popover--padded {
-  .popover__scroll-container {
-    @media (--from-tablet) {
-      padding: var(--s-space-4);
-    }
-  }
-}
-
-.popover__handle {
-  position: absolute;
-  top: var(--s-space-8);
-  left: 50%;
-  width: 2.5rem;
-  height: 0.375rem;
-  border-radius: 0.1875rem;
-  background-color: var(--s-border-default);
-  transform: translatex(-50%);
-
-  @media (--from-tablet) {
-    display: none;
   }
 }
 

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.spec.tsx
@@ -4,6 +4,7 @@ jest.mock("tabbable", () => ({
 
 import { newSpecPage, SpecPage } from "@stencil/core/testing";
 
+import * as bodyScrollLock from "../../utils/body-scroll-lock";
 import { SwirlPopoverTrigger } from "../swirl-popover-trigger/swirl-popover-trigger";
 import { SwirlPopover } from "./swirl-popover";
 
@@ -55,7 +56,7 @@ describe("swirl-popover", () => {
         </swirl-popover-trigger>
         <swirl-popover id="popover" label="Popover" style="display: none;">
           <mock:shadow-root>
-            <div class="popover popover--animation-scale-in-xy popover--inactive popover--padded popover--placement-undefined popover--translucent" popover="manual">
+            <div class="popover popover--animation-scale-in-xy popover--inactive popover--mobile-bottom-sheet popover--padded popover--placement-undefined popover--translucent" popover="manual">
               <div aria-hidden="true" aria-label="Popover" class="popover__content" part="popover__content" role="dialog" tabindex="-1" style="--swirl-popover-border-radius: var(--s-border-radius-base);">
                 <span class="popover__handle"></span>
                 <div class="popover__scroll-container" part="popover__scroll-container">
@@ -302,5 +303,108 @@ describe("swirl-popover", () => {
 
     expect(isPopoverOpen(page)).toBeFalsy();
     expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders as a bottom sheet on small viewports by default", async () => {
+    const page = await newSpecPage({
+      components: [SwirlPopover, SwirlPopoverTrigger],
+      html: template,
+    });
+
+    const popoverEl = page.doc
+      .querySelector("swirl-popover")
+      .shadowRoot.querySelector(".popover");
+
+    expect(
+      popoverEl.classList.contains("popover--mobile-bottom-sheet")
+    ).toBeTruthy();
+  });
+
+  it("does not render as a bottom sheet on small viewports when mobileBottomSheet is false", async () => {
+    const page = await newSpecPage({
+      components: [SwirlPopover, SwirlPopoverTrigger],
+      html: `
+        <div>
+          <swirl-popover-trigger swirl-popover="popover">
+            <button id="trigger">Trigger popover</button>
+          </swirl-popover-trigger>
+          <swirl-popover label="Popover" id="popover" mobile-bottom-sheet="false" style="display: none;">
+            <div>Content</div>
+          </swirl-popover>
+        </div>
+      `,
+    });
+
+    const shadowRoot = page.doc.querySelector("swirl-popover").shadowRoot;
+
+    expect(
+      shadowRoot
+        .querySelector(".popover")
+        .classList.contains("popover--mobile-bottom-sheet")
+    ).toBeFalsy();
+
+    expect(
+      shadowRoot
+        .querySelector<HTMLElement>(".popover__scroll-container")
+        .style.getPropertyValue("max-height")
+    ).toBe("22rem");
+  });
+
+  it("ignores fullscreenBottomSheet when mobileBottomSheet is false", async () => {
+    const page = await newSpecPage({
+      components: [SwirlPopover, SwirlPopoverTrigger],
+      html: `
+        <div>
+          <swirl-popover-trigger swirl-popover="popover">
+            <button id="trigger">Trigger popover</button>
+          </swirl-popover-trigger>
+          <swirl-popover label="Popover" id="popover" fullscreen-bottom-sheet mobile-bottom-sheet="false" style="display: none;">
+            <div>Content</div>
+          </swirl-popover>
+        </div>
+      `,
+    });
+
+    const popoverEl = page.doc
+      .querySelector("swirl-popover")
+      .shadowRoot.querySelector(".popover");
+
+    expect(
+      popoverEl.classList.contains("popover--fullscreen-bottom-sheet")
+    ).toBeFalsy();
+  });
+
+  it("does not lock the body scroll when mobileBottomSheet is false", async () => {
+    const page = await newSpecPage({
+      components: [SwirlPopover, SwirlPopoverTrigger],
+      html: `
+        <div>
+          <swirl-popover-trigger swirl-popover="popover">
+            <button id="trigger">Trigger popover</button>
+          </swirl-popover-trigger>
+          <swirl-popover label="Popover" id="popover" mobile-bottom-sheet="false" style="display: none;">
+            <div>Content</div>
+          </swirl-popover>
+        </div>
+      `,
+    });
+
+    const disableBodyScrollSpy = jest.spyOn(
+      bodyScrollLock,
+      "disableBodyScroll"
+    );
+
+    const popover =
+      page.body.querySelector<HTMLSwirlPopoverElement>("swirl-popover");
+    const trigger = page.body.querySelector<HTMLElement>("#trigger");
+
+    await popover.open(trigger);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    await page.waitForChanges();
+
+    expect(isPopoverOpen(page)).toBeTruthy();
+    expect(disableBodyScrollSpy).not.toHaveBeenCalled();
+
+    disableBodyScrollSpy.mockRestore();
   });
 });

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.stories.ts
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.stories.ts
@@ -8,6 +8,11 @@ export default {
         "You should disable the scroll lock for popovers inside modals and dialogs.",
       name: "disable-scroll-lock",
     },
+    mobileBottomSheet: {
+      description:
+        "By default, the popover opens as a bottom sheet on viewports below 768px. Pass false to keep it anchored to its trigger on all viewports, e.g. for popovers opened on hover.",
+      name: "mobile-bottom-sheet",
+    },
     offset: {
       description:
         "Pass a number to specify the main axis offset. Use an array to provide the main axis and cross axis offsets.",

--- a/packages/swirl-components/src/components/swirl-popover/swirl-popover.tsx
+++ b/packages/swirl-components/src/components/swirl-popover/swirl-popover.tsx
@@ -19,7 +19,10 @@ import {
   Prop,
   State,
 } from "@stencil/core";
-import { disableBodyScroll, enableBodyScroll } from "../../utils/body-scroll-lock";
+import {
+  disableBodyScroll,
+  enableBodyScroll,
+} from "../../utils/body-scroll-lock";
 import classnames from "classnames";
 import { tabbable } from "tabbable";
 import {
@@ -61,6 +64,7 @@ export class SwirlPopover {
   @Prop() fullscreenBottomSheet?: boolean;
   @Prop() label!: string;
   @Prop() maxHeight?: string = "22rem";
+  @Prop() mobileBottomSheet?: boolean = true;
   @Prop() offset?: number | number[] = 8;
   @Prop() padded?: boolean = true;
   @Prop() popoverId?: string;
@@ -320,6 +324,10 @@ export class SwirlPopover {
     }
   };
 
+  private get bottomSheetActive() {
+    return this.mobileBottomSheet && isMobileViewport();
+  }
+
   private connectTrigger() {
     if (!Boolean(this.trigger)) {
       this.triggerEl = undefined;
@@ -396,9 +404,7 @@ export class SwirlPopover {
       useContainerWidth = false;
     }
 
-    const mobile = !window.matchMedia("(min-width: 768px)").matches;
-
-    if (Boolean(useContainerWidth) && !mobile) {
+    if (Boolean(useContainerWidth) && !this.bottomSheetActive) {
       const container =
         typeof useContainerWidth === "string"
           ? this.el.closest(useContainerWidth) || this.el.parentElement
@@ -414,13 +420,11 @@ export class SwirlPopover {
   }
 
   private reposition = async () => {
-    const mobile = isMobileViewport();
-
     if (!Boolean(this.triggerEl) || !Boolean(this.contentContainer)) {
       return;
     }
 
-    if (mobile) {
+    if (this.bottomSheetActive) {
       this.position = undefined;
       return;
     }
@@ -461,9 +465,11 @@ export class SwirlPopover {
   };
 
   private lockBodyScroll() {
-    const mobile = isMobileViewport();
-
-    if (!mobile || this.disableScrollLock || !Boolean(this.scrollContainer)) {
+    if (
+      !this.bottomSheetActive ||
+      this.disableScrollLock ||
+      !Boolean(this.scrollContainer)
+    ) {
       return;
     }
 
@@ -471,9 +477,11 @@ export class SwirlPopover {
   }
 
   private unlockBodyScroll() {
-    const mobile = isMobileViewport();
-
-    if (!mobile || this.disableScrollLock || !Boolean(this.scrollContainer)) {
+    if (
+      !this.bottomSheetActive ||
+      this.disableScrollLock ||
+      !Boolean(this.scrollContainer)
+    ) {
       return;
     }
 
@@ -485,7 +493,7 @@ export class SwirlPopover {
   };
 
   render() {
-    const mobile = !window.matchMedia("(min-width: 768px)").matches;
+    const mobileBottomSheet = this.bottomSheetActive;
     const borderRadius = swirlPopoverBorderRadiusTokens.includes(
       this.borderRadius as (typeof swirlPopoverBorderRadiusTokens)[number]
     )
@@ -499,8 +507,10 @@ export class SwirlPopover {
       {
         "popover--active": this.active,
         "popover--closing": this.closing,
-        "popover--fullscreen-bottom-sheet": this.fullscreenBottomSheet,
+        "popover--fullscreen-bottom-sheet":
+          this.fullscreenBottomSheet && this.mobileBottomSheet,
         "popover--inactive": !this.active,
+        "popover--mobile-bottom-sheet": this.mobileBottomSheet,
         "popover--translucent": this.translucent && !this.transparent,
         "popover--transparent": this.transparent,
         "popover--padded": this.padded,
@@ -527,7 +537,9 @@ export class SwirlPopover {
               top: Boolean(this.position) ? `${this.position?.y}px` : "",
               left: Boolean(this.position) ? `${this.position?.x}px` : "",
               opacity:
-                this.active && !this.position && !mobile ? "0" : undefined,
+                this.active && !this.position && !mobileBottomSheet
+                  ? "0"
+                  : undefined,
               "--swirl-popover-border-radius": borderRadius,
             }}
             tabindex="-1"
@@ -539,7 +551,7 @@ export class SwirlPopover {
               ref={(el) => (this.scrollContainer = el)}
               style={{
                 maxHeight:
-                  !mobile && Boolean(this.maxHeight)
+                  !mobileBottomSheet && Boolean(this.maxHeight)
                     ? this.maxHeight
                     : undefined,
               }}

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -22334,6 +22334,10 @@
           "description": ""
         },
         {
+          "name": "mobile-bottom-sheet",
+          "description": ""
+        },
+        {
           "name": "offset",
           "description": ""
         },


### PR DESCRIPTION
## Summary

The popover always opened as a bottom sheet below 768px, which is awkward for popovers opened on hover.

This PR added a `mobileBottomSheet` property that defaults to true. Pass false to keep the popover anchored to its trigger on all viewports.
