### PR TITLE
feat: Add translucent variant to swirl-dialog

### DIFF
--- a/.changeset/clean-bags-scream.md
+++ b/.changeset/clean-bags-scream.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Add translucent variant to swirl-dialog

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -8173,6 +8173,9 @@
             },
             {
               "name": "dialog__heading"
+            },
+            {
+              "name": "dialog__scroll-container"
             }
           ]
         }

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -7933,6 +7933,13 @@
               },
               "default": "\"default\"",
               "fieldName": "size"
+            },
+            {
+              "name": "translucent",
+              "type": {
+                "text": "boolean"
+              },
+              "fieldName": "translucent"
             }
           ],
           "members": [
@@ -8032,6 +8039,15 @@
               "default": "\"default\"",
               "readonly": true,
               "attribute": "size"
+            },
+            {
+              "kind": "field",
+              "name": "translucent",
+              "type": {
+                "text": "boolean"
+              },
+              "readonly": true,
+              "attribute": "translucent"
             },
             {
               "kind": "method",

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -969,6 +969,7 @@ export namespace Components {
           * @default "default"
          */
         "size"?: SwirlDialogSize;
+        "translucent"?: boolean;
     }
     interface SwirlEmoji {
         /**
@@ -11451,6 +11452,7 @@ declare namespace LocalJSX {
           * @default "default"
          */
         "size"?: SwirlDialogSize;
+        "translucent"?: boolean;
     }
     interface SwirlEmoji {
         /**
@@ -16608,6 +16610,7 @@ declare namespace LocalJSX {
         "primaryActionLabel": string;
         "returnFocusTo": HTMLElement | string;
         "secondaryActionLabel": string;
+        "translucent": boolean;
     }
     interface SwirlEmojiAttributes {
         "label": string;

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
@@ -70,15 +70,10 @@
 }
 
 .dialog__body {
+  position: relative;
   z-index: var(--s-z-40);
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   width: 18.5rem;
-  max-height: 90vh;
-  padding-top: var(--s-space-24);
-  padding-right: var(--s-space-16);
-  padding-bottom: var(--s-space-16);
-  padding-left: var(--s-space-16);
   border-radius: var(--s-border-radius-l);
   background-color: var(--s-surface-overlay-default);
   text-align: center;
@@ -100,11 +95,30 @@
   }
 }
 
+.dialog__scroll-container {
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 90vh;
+  padding-top: var(--s-space-24);
+  padding-right: var(--s-space-16);
+  padding-bottom: var(--s-space-16);
+  padding-left: var(--s-space-16);
+}
+
 .dialog--translucent .dialog__body {
+  background-color: transparent;
   outline: var(--s-border-width-default) solid
     var(--s-border-translucent-outline);
-  background-color: var(--s-translucent-low-default);
-  backdrop-filter: blur(var(--s-blur-l));
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background: var(--s-translucent-low-default);
+    backdrop-filter: blur(var(--s-blur-l));
+    border-radius: inherit;
+  }
 }
 
 .dialog__heading {

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.css
@@ -53,11 +53,13 @@
 }
 
 .dialog--closing {
-  animation: 0.15s dialog-fade-out;
-  animation-fill-mode: forwards;
+  & .dialog__backdrop,
+  & .dialog__body {
+    animation: 0.15s dialog-fade-out forwards;
 
-  @media (prefers-reduced-motion) {
-    animation: none;
+    @media (prefers-reduced-motion) {
+      animation: none;
+    }
   }
 }
 
@@ -96,6 +98,13 @@
   @media (--from-desktop-without-touch) {
     width: 35rem; /* 560px */
   }
+}
+
+.dialog--translucent .dialog__body {
+  outline: var(--s-border-width-default) solid
+    var(--s-border-translucent-outline);
+  background-color: var(--s-translucent-low-default);
+  backdrop-filter: blur(var(--s-blur-l));
 }
 
 .dialog__heading {

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.spec.tsx
@@ -24,13 +24,15 @@ describe("swirl-dialog", () => {
           <dialog aria-describedby="content" aria-labelledby="label" class="dialog" closedby="none" role="alertdialog">
             <div class="dialog__backdrop"></div>
             <div class="dialog__body" part="dialog__body" role="document">
-              <h2 class="dialog__heading" part="dialog__heading" id="label">
-                Dialog
-              </h2>
-              <div class="dialog__content" part="dialog__content" id="content">
-                <slot></slot>
+              <div class="dialog__scroll-container" part="dialog__scroll-container">
+                <h2 class="dialog__heading" part="dialog__heading" id="label">
+                  Dialog
+                </h2>
+                <div class="dialog__content" part="dialog__content" id="content">
+                  <slot></slot>
+                </div>
+                <div class="dialog__controls"></div>
               </div>
-              <div class="dialog__controls"></div>
             </div>
           </dialog>
         </mock:shadow-root>
@@ -51,16 +53,18 @@ describe("swirl-dialog", () => {
           <dialog aria-describedby="content" aria-labelledby="label" class="dialog" closedby="none" role="alertdialog">
             <div class="dialog__backdrop"></div>
             <div class="dialog__body" part="dialog__body" role="document">
-              <h2 class="dialog__heading" part="dialog__heading" id="label">
-                Dialog
-              </h2>
-              <div class="dialog__content" part="dialog__content" id="content">
-                <slot></slot>
-              </div>
-              <div class="dialog__controls">
-                <div class="dialog__left_controls">
-                  <slot name="left-controls"></slot>
-                 </div>
+              <div class="dialog__scroll-container" part="dialog__scroll-container">
+                <h2 class="dialog__heading" part="dialog__heading" id="label">
+                  Dialog
+                </h2>
+                <div class="dialog__content" part="dialog__content" id="content">
+                  <slot></slot>
+                </div>
+                <div class="dialog__controls">
+                  <div class="dialog__left_controls">
+                    <slot name="left-controls"></slot>
+                   </div>
+                </div>
               </div>
             </div>
           </dialog>

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.spec.tsx
@@ -83,6 +83,17 @@ describe("swirl-dialog", () => {
     ).toBe("Dialog");
   });
 
+  it("renders a translucent surface", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDialog],
+      html: `<swirl-dialog translucent label="Dialog">Content</swirl-dialog>`,
+    });
+
+    expect(
+      page.root.shadowRoot.querySelector("dialog").className
+    ).toContain("dialog--translucent");
+  });
+
   it("renders controls and fires events", async () => {
     const page = await newSpecPage({
       components: [SwirlDialog],

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.stories.ts
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.stories.ts
@@ -66,4 +66,5 @@ SwirlDialog.args = {
   primaryActionLabel: "Leave",
   secondaryActionLabel: "Cancel",
   size: "default",
+  translucent: false,
 };

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.tsx
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.tsx
@@ -37,6 +37,7 @@ export class SwirlDialog {
   @Prop() primaryActionLabel?: string;
   @Prop() returnFocusTo?: HTMLElement | string;
   @Prop() secondaryActionLabel?: string;
+  @Prop() translucent?: boolean;
 
   @Event() dialogClose: EventEmitter<void>;
   @Event() dialogOpen: EventEmitter<void>;
@@ -182,6 +183,7 @@ export class SwirlDialog {
     const className = classnames("dialog", {
       "dialog--closing": this.closing,
       "dialog--large": this.size === "large",
+      "dialog--translucent": this.translucent,
     });
     const hasLeftControls = Boolean(
       this.el.querySelector('[slot="left-controls"]')

--- a/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.tsx
+++ b/packages/swirl-components/src/components/swirl-dialog/swirl-dialog.tsx
@@ -206,46 +206,55 @@ export class SwirlDialog {
         >
           <div class="dialog__backdrop" onClick={this.onBackdropClick}></div>
           <div class="dialog__body" part="dialog__body" role="document">
-            {!this.hideLabel && (
-              <h2 class="dialog__heading" part="dialog__heading" id="label">
-                {this.label}
-              </h2>
-            )}
-            <div class="dialog__content" part="dialog__content" id="content">
-              <slot></slot>
-            </div>
-            <div class="dialog__controls">
-              {hasLeftControls && (
-                <div class="dialog__left_controls">
-                  <slot name="left-controls"></slot>
-                </div>
+            <div
+              class="dialog__scroll-container"
+              part="dialog__scroll-container"
+            >
+              {!this.hideLabel && (
+                <h2 class="dialog__heading" part="dialog__heading" id="label">
+                  {this.label}
+                </h2>
               )}
+              <div
+                class="dialog__content"
+                part="dialog__content"
+                id="content"
+              >
+                <slot></slot>
+              </div>
+              <div class="dialog__controls">
+                {hasLeftControls && (
+                  <div class="dialog__left_controls">
+                    <slot name="left-controls"></slot>
+                  </div>
+                )}
 
-              {(hasSecondaryAction || hasPrimaryAction) && (
-                <swirl-button-group
-                  class={classnames("dialog__actions", {
-                    "dialog__actions--vertical":
-                      this.actionsOrientation === "vertical",
-                  })}
-                  orientation={this.actionsOrientation}
-                  stretch={this.actionsOrientation === "vertical"}
-                >
-                  {hasSecondaryAction && (
-                    <swirl-button
-                      label={this.secondaryActionLabel}
-                      onClick={this.onSecondaryAction}
-                    ></swirl-button>
-                  )}
-                  {hasPrimaryAction && (
-                    <swirl-button
-                      intent={this.intent}
-                      label={this.primaryActionLabel}
-                      onClick={this.onPrimaryAction}
-                      variant="flat"
-                    ></swirl-button>
-                  )}
-                </swirl-button-group>
-              )}
+                {(hasSecondaryAction || hasPrimaryAction) && (
+                  <swirl-button-group
+                    class={classnames("dialog__actions", {
+                      "dialog__actions--vertical":
+                        this.actionsOrientation === "vertical",
+                    })}
+                    orientation={this.actionsOrientation}
+                    stretch={this.actionsOrientation === "vertical"}
+                  >
+                    {hasSecondaryAction && (
+                      <swirl-button
+                        label={this.secondaryActionLabel}
+                        onClick={this.onSecondaryAction}
+                      ></swirl-button>
+                    )}
+                    {hasPrimaryAction && (
+                      <swirl-button
+                        intent={this.intent}
+                        label={this.primaryActionLabel}
+                        onClick={this.onPrimaryAction}
+                        variant="flat"
+                      ></swirl-button>
+                    )}
+                  </swirl-button-group>
+                )}
+              </div>
             </div>
           </div>
         </dialog>

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -2995,6 +2995,10 @@
               "name": "large"
             }
           ]
+        },
+        {
+          "name": "translucent",
+          "description": ""
         }
       ]
     },


### PR DESCRIPTION
## Summary

Swirl's design direction has been moving overlay surfaces to a "translucent" treatment: a
semi-transparent tinted fill plus a backdrop-filter blur and a light outline, built on the
--s-translucent-* / --s-blur-* token families added in 68007d00, dec171a6 and 8170faef.

swirl-popover gained this in 7b07609a (Add translucent popover variant) and now defaults to
translucent; swirl-card has an opt-in translucent boolean; swirl-menu hardcodes the same
recipe. swirl-dialog was never migrated — .dialog__body is still a fully opaque
--s-surface-overlay-default surface with --s-shadow-level-3.

The goal is to give swirl-dialog the same translucent option, with an API that matches the
existing precedent, so product teams can opt individual dialogs into the newer look without a
visual change for anyone who does not.

- [Ticket](#)
- [Design](#)
- [Storybook](#)
