### PR TITLE
Support centered avatar group layout symmetrical

### DIFF
--- a/.changeset/lazy-apes-battle.md
+++ b/.changeset/lazy-apes-battle.md
@@ -1,0 +1,8 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Enhance centered avatar group layout with 4-avatar arrangement and improved
+symmetry

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.css
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.css
@@ -93,24 +93,7 @@
   }
 }
 
-.avatar-group--centered-2 {
-  & ::slotted(:nth-child(1)) {
-    z-index: 2;
-    box-shadow: var(--s-shadow-level-2);
-  }
-
-  & ::slotted(:nth-child(2)) {
-    z-index: 1;
-    transform: scale(0.833333);
-    margin-right: calc(var(--swirl-avatar-size) * -0.083333);
-    margin-left: calc(var(--swirl-avatar-size) * -0.333333);
-  }
-
-  & ::slotted(:nth-child(n + 3)) {
-    display: none;
-  }
-}
-
+.avatar-group--centered-2,
 .avatar-group--centered-3 {
   /* centre */
   & ::slotted(:nth-child(1)) {
@@ -128,7 +111,19 @@
     margin-right: calc(var(--swirl-avatar-size) * -0.083333);
     margin-left: calc(var(--swirl-avatar-size) * -0.333333);
   }
+}
 
+.avatar-group--centered-2 {
+  & ::slotted(:nth-child(1)) {
+    margin-left: calc(var(--swirl-avatar-size) * 0.583334);
+  }
+
+  & ::slotted(:nth-child(n + 3)) {
+    display: none;
+  }
+}
+
+.avatar-group--centered-3 {
   /* left */
   & ::slotted(:nth-child(3)) {
     z-index: 1;
@@ -142,6 +137,7 @@
   }
 }
 
+.avatar-group--centered-4,
 .avatar-group--centered-5 {
   /* centre */
   & ::slotted(:nth-child(1)) {
@@ -175,7 +171,19 @@
     margin-right: calc(var(--swirl-avatar-size) * -0.166667);
     margin-left: calc(var(--swirl-avatar-size) * -0.5);
   }
+}
 
+.avatar-group--centered-4 {
+  & ::slotted(:nth-child(3)) {
+    margin-left: calc(var(--swirl-avatar-size) * 0.333333);
+  }
+
+  & ::slotted(:nth-child(n + 5)) {
+    display: none;
+  }
+}
+
+.avatar-group--centered-5 {
   /* outer left */
   & ::slotted(:nth-child(5)) {
     z-index: 1;

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.mdx
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.mdx
@@ -46,20 +46,28 @@ progressively smaller avatars flanking it on each side.
 
 <Canvas of={Stories.WithCenteredLayout}></Canvas>
 
+With 2 or 4 avatars, the leftmost slot (left for 2, outer left for 4) is left
+empty, but its space is still reserved so the main avatar remains centered:
+
+<Canvas of={Stories.WithCenteredLayoutTwoAvatars}></Canvas>
+
 Notes:
 
 - **Avatars are authored in importance order, not left-to-right order.** The
-  first child takes the centre, the second sits to its right, the third to its
-  left, and the fourth and fifth fill the outer right and outer left slots.
-- Every avatar should share the same `size`. Each one is sized and rounded
-  from the `--swirl-avatar-size` and `--swirl-avatar-radius` custom properties
-  its own `size`/`variant` publish, so mixing sizes produces an inconsistent
+  first child takes the centre, the second sits to its inner right, the third to
+  its inner left, the fourth to the outer right, and the fifth to the outer
+  left.
+- Every avatar should share the same `size`. Each one is sized and rounded from
+  the `--swirl-avatar-size` and `--swirl-avatar-radius` custom properties its
+  own `size`/`variant` publish, so mixing sizes produces an inconsistent
   arrangement rather than an error.
-- Only the first 5 avatars are shown. 4 avatars render using the 3-avatar
-  arrangement, with the 4th hidden; 6 or more avatars cap at the 5-avatar
-  arrangement. There's no "+N" indicator for hidden avatars.
-- The `badge` prop has no effect in this layout — the design has no badge
-  for this cluster.
+- Every count from 1 to 5 has its own arrangement, and a 2-avatar group is as
+  wide as a 3-avatar one, just as a 4-avatar group is as wide as a 5-avatar one
+  — only the left / outer-left slot stays empty. 6 or more avatars cap at the
+  5-avatar arrangement, with the extras hidden. There's no "+N" indicator for
+  hidden avatars.
+- The `badge` prop has no effect in this layout — the design has no badge for
+  this cluster.
 
 ## Related components
 

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.spec.tsx
@@ -38,7 +38,7 @@ describe("swirl-avatar-group", () => {
           `<swirl-avatar label="Person ${index}" size="${size}" variant="square"></swirl-avatar>`
       ).join("\n");
 
-    it("caps at the 3-avatar arrangement for 4 avatars", async () => {
+    it("uses its own 4-avatar arrangement for 4 avatars", async () => {
       const page = await newSpecPage({
         components: [SwirlAvatarGroup],
         html: `
@@ -55,7 +55,7 @@ describe("swirl-avatar-group", () => {
       const div = page.root.shadowRoot.querySelector(".avatar-group");
 
       expect(div.className).toContain("avatar-group--centered-stack");
-      expect(div.className).toContain("avatar-group--centered-3");
+      expect(div.className).toContain("avatar-group--centered-4");
     });
 
     it("caps at the 5-avatar arrangement for 6 avatars", async () => {
@@ -81,6 +81,7 @@ describe("swirl-avatar-group", () => {
       [1, "1"],
       [2, "2"],
       [3, "3"],
+      [4, "4"],
       [5, "5"],
     ])(
       "uses the %i-avatar arrangement for %i avatars",
@@ -105,6 +106,21 @@ describe("swirl-avatar-group", () => {
         );
       }
     );
+
+    it("falls back to the 1-avatar arrangement with no avatars", async () => {
+      const page = await newSpecPage({
+        components: [SwirlAvatarGroup],
+        html: `<swirl-avatar-group layout="centered"></swirl-avatar-group>`,
+      });
+      const slot = page.root.shadowRoot.querySelector("slot");
+      slot.dispatchEvent(new Event("slotchange"));
+
+      await page.waitForChanges();
+
+      const div = page.root.shadowRoot.querySelector(".avatar-group");
+
+      expect(div.className).toContain("avatar-group--centered-1");
+    });
 
     it("does not set position/z-index inline styles on its avatars", async () => {
       const page = await newSpecPage({

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.stories.ts
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.stories.ts
@@ -78,22 +78,32 @@ WithSquareAvatars.args = {
   layout: "horizontal",
 };
 
-const TemplateWithCenteredLayout = (args) => {
+const centeredLayoutAvatarMarkup = [
+  `<swirl-avatar label="Jane Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a" size="l" variant="square"></swirl-avatar>`,
+  `<swirl-avatar label="John Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=b" size="l" variant="square"></swirl-avatar>`,
+  `<swirl-avatar label="Jane Roe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=c" size="l" variant="square"></swirl-avatar>`,
+  `<swirl-avatar label="John Roe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=d" size="l" variant="square"></swirl-avatar>`,
+  `<swirl-avatar label="Jane Smith" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=e" size="l" variant="square"></swirl-avatar>`,
+];
+
+const createCenteredLayoutTemplate = (count: number) => (args) => {
   const element = generateStoryElement("swirl-avatar-group", args);
 
-  element.innerHTML = `
-    <swirl-avatar label="Jane Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=a" size="l" variant="square"></swirl-avatar>
-    <swirl-avatar label="John Doe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=b" size="l" variant="square"></swirl-avatar>
-    <swirl-avatar label="Jane Roe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=c" size="l" variant="square"></swirl-avatar>
-    <swirl-avatar label="John Roe" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=d" size="l" variant="square"></swirl-avatar>
-    <swirl-avatar label="Jane Smith" src="https://api.dicebear.com/7.x/bottts-neutral/svg?size=144&seed=e" size="l" variant="square"></swirl-avatar>
-  `;
+  element.innerHTML = centeredLayoutAvatarMarkup.slice(0, count).join("\n");
 
   return element;
 };
 
-export const WithCenteredLayout = TemplateWithCenteredLayout.bind({});
+export const WithCenteredLayout = createCenteredLayoutTemplate(5).bind({});
 
 WithCenteredLayout.args = {
+  layout: "centered",
+};
+
+export const WithCenteredLayoutTwoAvatars = createCenteredLayoutTemplate(
+  2
+).bind({});
+
+WithCenteredLayoutTwoAvatars.args = {
   layout: "centered",
 };

--- a/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar-group/swirl-avatar-group.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 export type SwirlAvatarGroupLayout = "centered" | "diagonal" | "horizontal";
 export type SwirlAvatarGroupSemantics = "list" | "group";
 
-const centeredLayoutArrangements = [1, 2, 3, 5];
+const maxCenteredLayoutAvatars = 5;
 
 /**
  * @slot slot - Your avatar components
@@ -64,13 +64,7 @@ export class SwirlAvatarGroup {
   }
 
   private getCenteredArrangement(): number {
-    const fittingArrangements = centeredLayoutArrangements.filter(
-      (arrangement) => arrangement <= this.avatars.length
-    );
-
-    return fittingArrangements.length > 0
-      ? fittingArrangements[fittingArrangements.length - 1]
-      : centeredLayoutArrangements[0];
+    return Math.min(Math.max(this.avatars.length, 1), maxCenteredLayoutAvatars);
   }
 
   render() {


### PR DESCRIPTION
## Summary

- Make swirl-avatar-group center layout symmetrical
- Support 4 avatar arrangement

- [Ticket](#)
- [Design](#)
- [Storybook](#)
