### PR TITLE
Interactive data cell

### DIFF
--- a/.changeset/tame-buses-jog.md
+++ b/.changeset/tame-buses-jog.md
@@ -1,0 +1,5 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Add `interactive`, `href`, `linkTarget` and `size` props to swirl-data-cell

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -7037,7 +7037,8 @@
               },
               "default": "\"m\"",
               "readonly": true,
-              "attribute": "size"
+              "attribute": "size",
+              "reflects": true
             },
             {
               "kind": "field",

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -6894,6 +6894,13 @@
           "name": "SwirlDataCell",
           "attributes": [
             {
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "href"
+            },
+            {
               "name": "intent",
               "type": {
                 "text": "\"critical\" | \"default\" | \"info\" | \"special\" | \"subdued\" | \"success\" | \"translucent\" | \"warning\"",
@@ -6907,11 +6914,39 @@
               "fieldName": "intent"
             },
             {
+              "name": "interactive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "interactive"
+            },
+            {
               "name": "label",
               "type": {
                 "text": "string"
               },
               "fieldName": "label"
+            },
+            {
+              "name": "link-target",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "linkTarget"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "\"m\" | \"s\"",
+                "references": [
+                  {
+                    "name": "SwirlDataCellSize"
+                  }
+                ]
+              },
+              "default": "\"m\"",
+              "fieldName": "size"
             },
             {
               "name": "tooltip",
@@ -6939,6 +6974,15 @@
           "members": [
             {
               "kind": "field",
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "href"
+            },
+            {
+              "kind": "field",
               "name": "intent",
               "type": {
                 "text": "\"critical\" | \"default\" | \"info\" | \"special\" | \"subdued\" | \"success\" | \"translucent\" | \"warning\"",
@@ -6954,12 +6998,46 @@
             },
             {
               "kind": "field",
+              "name": "interactive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "interactive"
+            },
+            {
+              "kind": "field",
               "name": "label",
               "type": {
                 "text": "string"
               },
               "readonly": true,
               "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "linkTarget",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "link-target"
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "\"m\" | \"s\"",
+                "references": [
+                  {
+                    "name": "SwirlDataCellSize"
+                  }
+                ]
+              },
+              "default": "\"m\"",
+              "readonly": true,
+              "attribute": "size"
             },
             {
               "kind": "field",

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -25,7 +25,7 @@ import { SwirlCarouselFadeColor, SwirlCarouselPadding, SwirlCarouselSpacing } fr
 import { SwirlCheckboxLabelWeight, SwirlCheckboxState, SwirlCheckboxVariant } from "./components/swirl-checkbox/swirl-checkbox";
 import { SwirlChipIconColor, SwirlChipIntent } from "./components/swirl-chip/swirl-chip";
 import { SwirlColumnsSpacing } from "./components/swirl-columns/swirl-columns";
-import { SwirlDataCellIntent } from "./components/swirl-data-cell/swirl-data-cell";
+import { SwirlDataCellIntent, SwirlDataCellSize } from "./components/swirl-data-cell/swirl-data-cell";
 import { WCDatepickerLabels } from "wc-datepicker/dist/types/components/wc-datepicker/wc-datepicker";
 import { SwirlButtonGroupOrientation as SwirlButtonGroupOrientation1 } from "./components/swirl-button-group/swirl-button-group";
 import { SwirlDialogIntent, SwirlDialogSize } from "./components/swirl-dialog/swirl-dialog";
@@ -109,7 +109,7 @@ export { SwirlCarouselFadeColor, SwirlCarouselPadding, SwirlCarouselSpacing } fr
 export { SwirlCheckboxLabelWeight, SwirlCheckboxState, SwirlCheckboxVariant } from "./components/swirl-checkbox/swirl-checkbox";
 export { SwirlChipIconColor, SwirlChipIntent } from "./components/swirl-chip/swirl-chip";
 export { SwirlColumnsSpacing } from "./components/swirl-columns/swirl-columns";
-export { SwirlDataCellIntent } from "./components/swirl-data-cell/swirl-data-cell";
+export { SwirlDataCellIntent, SwirlDataCellSize } from "./components/swirl-data-cell/swirl-data-cell";
 export { WCDatepickerLabels } from "wc-datepicker/dist/types/components/wc-datepicker/wc-datepicker";
 export { SwirlButtonGroupOrientation as SwirlButtonGroupOrientation1 } from "./components/swirl-button-group/swirl-button-group";
 export { SwirlDialogIntent, SwirlDialogSize } from "./components/swirl-dialog/swirl-dialog";
@@ -838,11 +838,21 @@ export namespace Components {
         "toggleSidebar": () => Promise<void>;
     }
     interface SwirlDataCell {
+        "href"?: string;
         /**
           * @default "default"
          */
         "intent"?: SwirlDataCellIntent;
+        /**
+          * @default false
+         */
+        "interactive"?: boolean;
         "label"?: string;
+        "linkTarget"?: string;
+        /**
+          * @default "m"
+         */
+        "size"?: SwirlDataCellSize;
         "tooltip"?: string;
         "value"?: string;
         /**
@@ -11333,12 +11343,22 @@ declare namespace LocalJSX {
         "subheading"?: string;
     }
     interface SwirlDataCell {
+        "href"?: string;
         /**
           * @default "default"
          */
         "intent"?: SwirlDataCellIntent;
+        /**
+          * @default false
+         */
+        "interactive"?: boolean;
         "label"?: string;
+        "linkTarget"?: string;
         "onValueChange"?: (event: SwirlDataCellCustomEvent<MouseEvent>) => void;
+        /**
+          * @default "m"
+         */
+        "size"?: SwirlDataCellSize;
         "tooltip"?: string;
         "value"?: string;
         /**
@@ -16577,8 +16597,12 @@ declare namespace LocalJSX {
         "hideContentHeader": boolean;
     }
     interface SwirlDataCellAttributes {
+        "href": string;
         "intent": SwirlDataCellIntent;
+        "interactive": boolean;
         "label": string;
+        "linkTarget": string;
+        "size": SwirlDataCellSize;
         "tooltip": string;
         "value": string;
         "vertical": boolean;

--- a/packages/swirl-components/src/components/swirl-data-cell-stack/swirl-data-cell-stack.css
+++ b/packages/swirl-components/src/components/swirl-data-cell-stack/swirl-data-cell-stack.css
@@ -77,6 +77,30 @@
   --swirl-data-cell-border-radius: var(--s-border-radius-l);
 }
 
+.data-cell-stack__cells
+  ::slotted(swirl-data-cell[size="s"]:first-of-type:not(:last-of-type)) {
+  --swirl-data-cell-border-radius: var(--s-border-radius-base)
+    var(--s-border-radius-base) var(--s-border-radius-s) var(--s-border-radius-s);
+}
+
+.data-cell-stack__cells
+  ::slotted(swirl-data-cell[size="s"]:last-of-type:not(:first-of-type)) {
+  --swirl-data-cell-border-radius: var(--s-border-radius-s)
+    var(--s-border-radius-s) var(--s-border-radius-base) var(--s-border-radius-base);
+}
+
+.data-cell-stack__cells
+  ::slotted(
+    swirl-data-cell[size="s"]:not(:first-of-type):not(:last-of-type)
+  ) {
+  --swirl-data-cell-border-radius: var(--s-border-radius-s);
+}
+
+.data-cell-stack__cells
+  ::slotted(swirl-data-cell[size="s"]:first-of-type:last-of-type) {
+  --swirl-data-cell-border-radius: var(--s-border-radius-base);
+}
+
 .data-cell-stack__cta {
   display: flex;
   align-items: center;

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
@@ -51,14 +51,6 @@
   &:focus-visible {
     outline-color: var(--s-focus-default);
   }
-
-  &:hover .data-cell__media ::slotted(swirl-avatar) {
-    --swirl-avatar-background-color: var(--s-surface-raised-hovered);
-  }
-
-  &:active .data-cell__media ::slotted(swirl-avatar) {
-    --swirl-avatar-background-color: var(--s-surface-raised-pressed);
-  }
 }
 
 .data-cell--interactive.data-cell--intent-default {

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
@@ -112,7 +112,7 @@
 .data-cell--size-s {
   gap: var(--s-space-4);
   padding: var(--s-space-8);
-  border-radius: var(--s-border-radius-s);
+  border-radius: var(--swirl-data-cell-border-radius, var(--s-border-radius-s));
 
   & .data-cell__content {
     gap: var(--s-space-8);

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.css
@@ -15,11 +15,65 @@
   gap: var(--s-space-8);
   width: 100%;
   padding: var(--s-space-12) var(--s-space-16);
+  border: 0;
   border-radius: var(--swirl-data-cell-border-radius, var(--s-border-radius-l));
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-decoration: none;
+  appearance: none;
 }
 
 .data-cell--interactive {
+  position: relative;
   cursor: pointer;
+
+  &::after {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    content: "";
+    pointer-events: none;
+  }
+
+  &:hover::after {
+    background-color: var(--s-state-hovered);
+  }
+
+  &:active::after {
+    background-color: var(--s-state-pressed);
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline-color: var(--s-focus-default);
+  }
+
+  &:hover .data-cell__media ::slotted(swirl-avatar) {
+    --swirl-avatar-background-color: var(--s-surface-raised-hovered);
+  }
+
+  &:active .data-cell__media ::slotted(swirl-avatar) {
+    --swirl-avatar-background-color: var(--s-surface-raised-pressed);
+  }
+}
+
+.data-cell--interactive.data-cell--intent-default {
+  &:hover {
+    background-color: var(--s-surface-raised-50-hovered);
+  }
+
+  &:active {
+    background-color: var(--s-surface-raised-50-pressed);
+  }
+
+  &:hover::after,
+  &:active::after {
+    background-color: transparent;
+  }
 }
 
 /* Intent backgrounds */
@@ -53,6 +107,20 @@
 
 .data-cell--intent-subdued {
   background-color: var(--s-surface-raised-default);
+}
+
+.data-cell--size-s {
+  gap: var(--s-space-4);
+  padding: var(--s-space-8);
+  border-radius: var(--s-border-radius-s);
+
+  & .data-cell__content {
+    gap: var(--s-space-8);
+  }
+
+  & .data-cell__value {
+    font-weight: var(--s-font-weight-medium);
+  }
 }
 
 .data-cell--vertical {

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.mdx
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.mdx
@@ -30,12 +30,16 @@ the content slot, allowing for editable data cells with inputs and selects.
 
 ## Properties
 
-| Property   | Attribute  | Description                                                 | Type      | Default     |
-| ---------- | ---------- | ----------------------------------------------------------- | --------- | ----------- |
-| `label`    | `label`    | Required label text                                         | `string`  | -           |
-| `tooltip`  | `tooltip`  | Optional tooltip content (displays info icon next to label) | `string`  | `undefined` |
-| `value`    | `value`    | Optional value text (ignored when input slot is used)       | `string`  | `undefined` |
-| `vertical` | `vertical` | Force vertical layout (default: false)                      | `boolean` | `false`     |
+| Property      | Attribute      | Description                                                                 | Type                | Default     |
+| ------------- | -------------- | ---------------------------------------------------------------------------- | ------------------- | ----------- |
+| `href`        | `href`         | Renders the cell as a link to this URL                                     | `string`             | `undefined` |
+| `interactive` | `interactive`  | Renders the cell as a clickable, keyboard-focusable button                 | `boolean`            | `false`     |
+| `label`       | `label`        | Required label text                                                         | `string`             | -           |
+| `linkTarget`  | `link-target`  | Target for the `href` link (adds `rel="noreferrer"` for `_blank`)          | `string`             | `undefined` |
+| `size`        | `size`         | Cell size: `"m"` (default) or `"s"` (compact, e.g. for channel-style rows) | `"m" \| "s"`         | `"m"`       |
+| `tooltip`     | `tooltip`      | Optional tooltip content (displays info icon next to label)                | `string`             | `undefined` |
+| `value`       | `value`        | Optional value text (ignored when input slot is used)                     | `string`             | `undefined` |
+| `vertical`    | `vertical`     | Force vertical layout (default: false)                                    | `boolean`            | `false`     |
 
 ## Slots
 
@@ -44,6 +48,39 @@ the content slot, allowing for editable data cells with inputs and selects.
 | `media`   | Optional media content (e.g., swirl-avatar, icons).                                               |
 | `content` | Optional content element (e.g., swirl-text-input, swirl-select). When provided, value is ignored. |
 | `suffix`  | Optional suffix content (e.g., buttons, badges)                                                   |
+
+## Interactive cells
+
+Use the `interactive` prop to make the whole cell clickable. It renders the
+cell as a native button, so consumers listen for the native `click` event, and
+it overlays the cell with hovered, pressed and focused states that work with
+every intent. Set `href` (and optionally `linkTarget`) instead to render the
+cell as a link.
+
+<Source code={`<swirl-data-cell interactive value="Feedback & Ideas">
+    <swirl-avatar slot="media" label="Feedback & Ideas" size="s"></swirl-avatar>
+</swirl-data-cell>
+
+<swirl-data-cell href="/channels/feedback" value="Feedback & Ideas">
+    <swirl-avatar slot="media" label="Feedback & Ideas" size="s"></swirl-avatar>
+</swirl-data-cell>`}
+/>
+
+Avoid combining `interactive`/`href` with the `content` slot or with
+interactive `suffix` content: the cell becomes a native button or link, so
+nesting another interactive element inside it is invalid HTML.
+
+## Compact cells
+
+Use `size="s"` for a denser row — 8px padding, a 4px radius and a medium-weight
+value — typically paired with a 24px (`size="s"`) avatar in the `media` slot,
+as in the channel-picker style row.
+
+<Source code={`<swirl-data-cell interactive size="s" value="Feedback & Ideas">
+    <swirl-avatar slot="media" label="Feedback & Ideas" size="s"></swirl-avatar>
+    <swirl-tag slot="suffix" label="Approval" intent="warning"></swirl-tag>
+</swirl-data-cell>`}
+/>
 
 ## Related components
 
@@ -55,19 +92,28 @@ the content slot, allowing for editable data cells with inputs and selects.
 
 ### ARIA
 
-The component structures label-value pairs for assistive technologies.
+The component structures label-value pairs for assistive technologies. When
+`interactive` or `href` is set, the cell renders as a native button or link
+instead, so the `term`/`definition` roles are omitted — a button/link already
+computes its accessible name from its contents.
 
-| ARIA                | Usage                                                             |
-| ------------------- | ----------------------------------------------------------------- |
-| `role="group"`      | Set on the host when `swirl-data-cell` is used standalone.        |
-| `role="listitem"`   | Set on the host when `swirl-data-cell` is used in a stack/list.   |
-| `role="term"`       | Set on the label element.                                         |
-| `role="definition"` | Set on the value/definition container.                            |
-| `aria-labelledby`   | Set on the definition, referencing the label ID.                  |
-| `aria-hidden`       | Set on the media container when present.                          |
-| `role="button"`     | Optional; set when the cell contains a checkbox or radio control. |
+| ARIA                | Usage                                                                                    |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| `role="group"`      | Set on the host when `swirl-data-cell` is used standalone.                               |
+| `role="listitem"`   | Set on the host when `swirl-data-cell` is used in a stack/list.                          |
+| `role="term"`       | Set on the label element (omitted when `interactive`/`href` is set).                      |
+| `role="definition"` | Set on the value/definition container (omitted when `interactive`/`href` is set).         |
+| `aria-labelledby`   | Set on the definition, referencing the label ID (omitted when `interactive`/`href` is set). |
+| `aria-hidden`       | Set on the media container when present.                                                  |
+| `role="button"`     | Optional; set when the cell contains a checkbox or radio control.                        |
 
 ### Keyboard
 
-Keyboard behavior is determined by slotted content (e.g. form controls). No
-component-specific shortcuts.
+Keyboard behavior is determined by slotted content (e.g. form controls), plus
+the following when `interactive` or `href` is set:
+
+| Key             | Action                                    |
+| --------------- | ------------------------------------------ |
+| <kbd>TAB</kbd>  | Moves focus to/from the cell.              |
+| <kbd>ENTER</kbd> | Activates the interactive cell or link.   |
+| <kbd>SPACE</kbd> | Activates the interactive cell (buttons only). |

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.spec.tsx
@@ -426,4 +426,110 @@ describe("swirl-data-cell", () => {
     expect(radios[0]?.getAttribute("value")).toBe("standard");
     expect(radios[0]?.getAttribute("input-name")).toBe("plan");
   });
+
+  it("renders as a div by default", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const dataCell = page.root.shadowRoot.querySelector(".data-cell");
+    expect(dataCell?.tagName).toBe("DIV");
+    expect(
+      dataCell?.classList.contains("data-cell--interactive")
+    ).toBeFalsy();
+  });
+
+  it("renders as a button when interactive", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell interactive value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const dataCell = page.root.shadowRoot.querySelector(".data-cell");
+    expect(dataCell?.tagName).toBe("BUTTON");
+    expect(dataCell?.getAttribute("type")).toBe("button");
+    expect(
+      dataCell?.classList.contains("data-cell--interactive")
+    ).toBeTruthy();
+    expect(dataCell?.getAttribute("role")).toBeNull();
+    expect(dataCell?.getAttribute("tabindex")).toBeNull();
+  });
+
+  it("renders as a link when href is set", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell href="/channels/feedback" value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const dataCell = page.root.shadowRoot.querySelector(".data-cell");
+    expect(dataCell?.tagName).toBe("A");
+    expect(dataCell?.getAttribute("href")).toBe("/channels/feedback");
+    expect(
+      dataCell?.classList.contains("data-cell--interactive")
+    ).toBeTruthy();
+    expect(dataCell?.getAttribute("rel")).toBeNull();
+  });
+
+  it("adds rel=noreferrer when href opens in a new tab", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell href="/channels/feedback" link-target="_blank" value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const dataCell = page.root.shadowRoot.querySelector(".data-cell");
+    expect(dataCell?.getAttribute("target")).toBe("_blank");
+    expect(dataCell?.getAttribute("rel")).toBe("noreferrer");
+  });
+
+  it("emits a native click event when interactive", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell interactive value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const button = page.root.shadowRoot.querySelector(".data-cell");
+    const spy = jest.fn();
+
+    page.root.addEventListener("click", spy);
+    (button as HTMLElement).click();
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("omits label/value definition-list roles when interactive", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell interactive label="Name" value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const label = page.root.shadowRoot.querySelector(".data-cell__label");
+    expect(label?.getAttribute("role")).toBeNull();
+
+    const valueWrapper = page.root.shadowRoot.querySelector(
+      ".data-cell__value-wrapper"
+    );
+    expect(valueWrapper?.getAttribute("role")).toBeNull();
+    expect(valueWrapper?.getAttribute("aria-labelledby")).toBeNull();
+  });
+
+  it("applies the medium size by default", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const dataCell = page.root.shadowRoot.querySelector(".data-cell");
+    expect(dataCell?.classList.contains("data-cell--size-m")).toBeTruthy();
+  });
+
+  it("applies the small size", async () => {
+    const page = await newSpecPage({
+      components: [SwirlDataCell],
+      html: `<swirl-data-cell size="s" value="Feedback & Ideas"></swirl-data-cell>`,
+    });
+
+    const dataCell = page.root.shadowRoot.querySelector(".data-cell");
+    expect(dataCell?.classList.contains("data-cell--size-s")).toBeTruthy();
+  });
 });

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.stories.ts
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.stories.ts
@@ -216,6 +216,30 @@ export const WithCheckbox = () => {
   return stack;
 };
 
+export const InteractiveCompactCells = () => {
+  const stack = generateStoryElement("swirl-data-cell-stack", {});
+
+  stack.innerHTML = `
+    <!-- Compact interactive cell -->
+    <swirl-data-cell interactive size="s" value="Feedback & Ideas">
+      <swirl-avatar slot="media" label="Feedback & Ideas" icon="<swirl-icon-chat-bubble></swirl-icon-chat-bubble>" size="s"></swirl-avatar>
+    </swirl-data-cell>
+
+    <!-- Compact interactive cell with a trailing tag -->
+    <swirl-data-cell interactive size="s" value="Approvals">
+      <swirl-avatar slot="media" label="Approvals" icon="<swirl-icon-chat-bubble></swirl-icon-chat-bubble>" size="s"></swirl-avatar>
+      <swirl-tag slot="suffix" label="Approval" intent="warning"></swirl-tag>
+    </swirl-data-cell>
+
+    <!-- Compact cell rendered as a link -->
+    <swirl-data-cell href="#" size="s" value="Announcements">
+      <swirl-avatar slot="media" label="Announcements" icon="<swirl-icon-chat-bubble></swirl-icon-chat-bubble>" size="s"></swirl-avatar>
+    </swirl-data-cell>
+  `;
+
+  return stack;
+};
+
 export const WithRadioButton = () => {
   const stack = generateStoryElement("swirl-data-cell-stack", {});
 

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.tsx
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.tsx
@@ -19,6 +19,8 @@ export type SwirlDataCellIntent =
   | "translucent"
   | "subdued";
 
+export type SwirlDataCellSize = "s" | "m";
+
 /**
  * @slot media - Optional media content (e.g., swirl-avatar, icons). Only swirl-avatar and icon elements are styled.
  * @slot content - Optional content element (e.g., swirl-text-input, swirl-select). When provided, the value prop is ignored. Content automatically takes 100% width when no label is present.
@@ -32,8 +34,12 @@ export type SwirlDataCellIntent =
 export class SwirlDataCell {
   @Element() el: HTMLElement;
 
+  @Prop() href?: string;
   @Prop() intent?: SwirlDataCellIntent = "default";
+  @Prop() interactive?: boolean = false;
   @Prop() label?: string;
+  @Prop() linkTarget?: string;
+  @Prop() size?: SwirlDataCellSize = "m";
   @Prop() tooltip?: string;
   @Prop() value?: string;
   @Prop() vertical?: boolean = false;
@@ -80,14 +86,15 @@ export class SwirlDataCell {
     const hasRadio = Boolean(
       this.el.querySelector('swirl-radio[slot="content"]')
     );
+    const isInteractive = this.interactive || Boolean(this.href);
 
-    const className = classnames("data-cell", {
+    const className = classnames("data-cell", `data-cell--size-${this.size}`, {
       "data-cell--vertical": this.vertical,
       "data-cell--has-media": hasMedia,
       "data-cell--has-suffix": hasSuffix,
       "data-cell--has-content": hasContent,
       "data-cell--no-label": !hasLabel,
-      "data-cell--interactive": hasCheckbox || hasRadio,
+      "data-cell--interactive": isInteractive || hasCheckbox || hasRadio,
       [`data-cell--intent-${this.intent}`]: this.intent,
     });
 
@@ -100,9 +107,15 @@ export class SwirlDataCell {
     const wrapperRole =
       isInDataCellStack && !contentRole ? "group" : contentRole;
 
+    const Tag = Boolean(this.href) ? "a" : this.interactive ? "button" : "div";
+
     const labelContent = (
       <swirl-stack orientation="horizontal" align="center" spacing="4">
-        <span class="data-cell__label" id={labelId} role="term">
+        <span
+          class="data-cell__label"
+          id={labelId}
+          role={isInteractive ? undefined : "term"}
+        >
           {this.label}
         </span>
         {this.tooltip && (
@@ -119,12 +132,28 @@ export class SwirlDataCell {
 
     return (
       <Host role={hostRole}>
-        <div
+        <Tag
           class={className}
-          part="data-cell"
+          href={this.href}
           onClick={hasCheckbox || hasRadio ? this.handleClick : undefined}
-          role={wrapperRole}
-          tabIndex={hasCheckbox || hasRadio ? 0 : undefined}
+          part="data-cell"
+          rel={
+            Boolean(this.href) && this.linkTarget === "_blank"
+              ? "noreferrer"
+              : undefined
+          }
+          role={isInteractive ? undefined : wrapperRole}
+          tabIndex={
+            isInteractive ? undefined : hasCheckbox || hasRadio ? 0 : undefined
+          }
+          target={this.linkTarget}
+          type={
+            Boolean(this.href)
+              ? undefined
+              : this.interactive
+              ? "button"
+              : undefined
+          }
         >
           {hasMedia && (
             <div class="data-cell__media" aria-hidden="true">
@@ -138,8 +167,10 @@ export class SwirlDataCell {
             {(hasContent || this.value || hasSuffix) && (
               <div
                 class="data-cell__value-wrapper"
-                role="definition"
-                aria-labelledby={hasLabel ? labelId : undefined}
+                role={isInteractive ? undefined : "definition"}
+                aria-labelledby={
+                  hasLabel && !isInteractive ? labelId : undefined
+                }
                 id={valueId}
               >
                 {hasContent ? (
@@ -157,7 +188,7 @@ export class SwirlDataCell {
               <slot name="suffix"></slot>
             </div>
           )}
-        </div>
+        </Tag>
       </Host>
     );
   }

--- a/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.tsx
+++ b/packages/swirl-components/src/components/swirl-data-cell/swirl-data-cell.tsx
@@ -39,7 +39,7 @@ export class SwirlDataCell {
   @Prop() interactive?: boolean = false;
   @Prop() label?: string;
   @Prop() linkTarget?: string;
-  @Prop() size?: SwirlDataCellSize = "m";
+  @Prop({ reflect: true }) size?: SwirlDataCellSize = "m";
   @Prop() tooltip?: string;
   @Prop() value?: string;
   @Prop() vertical?: boolean = false;

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -2719,6 +2719,10 @@
       },
       "attributes": [
         {
+          "name": "href",
+          "description": ""
+        },
+        {
           "name": "intent",
           "description": "",
           "values": [
@@ -2749,8 +2753,28 @@
           ]
         },
         {
+          "name": "interactive",
+          "description": ""
+        },
+        {
           "name": "label",
           "description": ""
+        },
+        {
+          "name": "link-target",
+          "description": ""
+        },
+        {
+          "name": "size",
+          "description": "",
+          "values": [
+            {
+              "name": "m"
+            },
+            {
+              "name": "s"
+            }
+          ]
         },
         {
           "name": "tooltip",


### PR DESCRIPTION
## Summary


Adds an interactive, keyboard-navigable variant of swirl-data-cell to support the Figma "Channel cell" design (compact rows with avatar + name + optional tag used in the Post Success Modal), and fixes its rounded-corner behavior when grouped in a swirl-data-cell-stack.

Changes:
- New interactive prop — renders the cell as a native <button> (clickable + keyboard-operable via native Tab/Enter/Space, no custom key handling needed)
- New href / linkTarget props — renders the cell as an <a> when a link target is needed
- New size prop ("s" | "m") — compact (s) sizing matches the Figma channel-cell spec (8px padding, 4px radius, 4px gap)
- Hover/pressed/focus-visible states added for interactive cells across all intents
- Fixed compact (size="s") cells to properly honor first/last-cell corner rounding when grouped inside swirl-data-cell-stack, matching Figma's grouped-list corner treatment (12px outer / 4px touching corners) instead of always rendering flat corners
- 
- [Ticket](#)
- [Design](#)
- [Storybook](#)
