### PR TITLE
feat: change swirl-avatar default color to neutral

### DIFF
--- a/.changeset/quiet-kiwi-to-neutral.md
+++ b/.changeset/quiet-kiwi-to-neutral.md
@@ -1,0 +1,7 @@
+---
+"@getflip/swirl-components": minor
+"@getflip/swirl-components-angular": minor
+"@getflip/swirl-components-react": minor
+---
+
+Change swirl-avatar default `color` from `kiwi` to `neutral`

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -2197,7 +2197,7 @@
                   }
                 ]
               },
-              "default": "\"kiwi\"",
+              "default": "\"neutral\"",
               "fieldName": "color"
             },
             {
@@ -2332,7 +2332,7 @@
                   }
                 ]
               },
-              "default": "\"kiwi\"",
+              "default": "\"neutral\"",
               "readonly": true,
               "attribute": "color"
             },

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -410,7 +410,7 @@ export namespace Components {
          */
         "badgePosition"?: SwirlAvatarBadgePosition;
         /**
-          * @default "kiwi"
+          * @default "neutral"
          */
         "color"?: SwirlAvatarColor;
         "icon"?: string;
@@ -10911,7 +10911,7 @@ declare namespace LocalJSX {
          */
         "badgePosition"?: SwirlAvatarBadgePosition;
         /**
-          * @default "kiwi"
+          * @default "neutral"
          */
         "color"?: SwirlAvatarColor;
         "icon"?: string;

--- a/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.spec.tsx
@@ -12,7 +12,7 @@ describe("swirl-avatar", () => {
     expect(page.root).toEqualHtml(`
       <swirl-avatar label="John Doe" size="m" variant="round">
         <mock:shadow-root>
-          <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
+          <span class="avatar avatar--color-neutral avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
               <swirl-icon-person></swirl-icon-person>
             </span>
@@ -41,7 +41,7 @@ describe("swirl-avatar", () => {
     expect(page.root).toEqualHtml(`
       <swirl-avatar label="John Doe" size="m" src="https://" variant="round">
         <mock:shadow-root>
-          <span class="avatar avatar--color-kiwi avatar--size-m avatar--variant-round" part="avatar">
+          <span class="avatar avatar--color-neutral avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__image">
               <img alt="" height="40" src="https://" width="40">
             </span>
@@ -63,7 +63,7 @@ describe("swirl-avatar", () => {
     expect(page.root).toEqualHtml(`
       <swirl-avatar initials="JD" label="John Doe" size="m" variant="round">
         <mock:shadow-root>
-          <span class="avatar avatar--color-kiwi avatar--has-initials avatar--size-m avatar--variant-round" part="avatar">
+          <span class="avatar avatar--color-neutral avatar--has-initials avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__initials">
               <span>
                 JD
@@ -87,7 +87,7 @@ describe("swirl-avatar", () => {
     expect(page.root).toEqualHtml(`
       <swirl-avatar icon="<swirl-icon-close></swirl-icon-close>" label="John Doe" size="m" variant="round">
         <mock:shadow-root>
-          <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
+          <span class="avatar avatar--color-neutral avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
               <swirl-icon-close></swirl-icon-close>
             </span>
@@ -155,7 +155,7 @@ describe("swirl-avatar", () => {
     expect(page.root).toEqualHtml(`
       <swirl-avatar badge="<swirl-badge aria-label='3 new messages' label='3'></swirl-badge>" badge-position="top" label="John Doe" size="m" variant="round">
         <mock:shadow-root>
-          <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
+          <span class="avatar avatar--color-neutral avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
               <swirl-icon-person></swirl-icon-person>
             </span>
@@ -180,7 +180,7 @@ describe("swirl-avatar", () => {
     expect(page.root).toEqualHtml(`
       <swirl-avatar label="John Doe" show-label="" size="m" variant="round">
         <mock:shadow-root>
-          <span class="avatar avatar--color-kiwi avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
+          <span class="avatar avatar--color-neutral avatar--has-icon avatar--size-m avatar--variant-round" part="avatar">
             <span class="avatar__icon">
               <swirl-icon-person></swirl-icon-person>
             </span>

--- a/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
+++ b/packages/swirl-components/src/components/swirl-avatar/swirl-avatar.tsx
@@ -63,7 +63,7 @@ export class SwirlAvatar {
 
   @Prop() badge?: string;
   @Prop() badgePosition?: SwirlAvatarBadgePosition = "bottom";
-  @Prop() color?: SwirlAvatarColor = "kiwi";
+  @Prop() color?: SwirlAvatarColor = "neutral";
   @Prop() icon?: string;
   @Prop() initials?: string;
   @Prop() interactive?: boolean = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- [Ticket](https://linear.app/issue/ORC-1198)
- [Design](#)
- [Storybook](#)

Changes the `swirl-avatar` `color` property default from `kiwi` to `neutral`, as requested in ORC-1198. Avatars without an explicit color now use the neutral decorative tokens.

Also updates:
- Spec snapshots that asserted `avatar--color-kiwi`
- Generated Stencil type docs and custom elements manifest defaults
- Changeset for the published swirl-components packages

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ORC-1198](https://linear.app/flip/issue/ORC-1198/test-change-default-avatar-color-to-neutral)

<div><a href="https://cursor.com/agents/bc-25ac95e0-8ffc-44ab-b04d-24ebe9597333?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25ac95e0-8ffc-44ab-b04d-24ebe9597333&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

