### PR TITLE
feat: add generic tree view to swirl-table (SWR-147)

### DIFF
--- a/.changeset/table-tree-view.md
+++ b/.changeset/table-tree-view.md
@@ -1,0 +1,6 @@
+---
+"@getflip/swirl-components": minor
+---
+
+Add a generic tree view to swirl-table with expandable rows, computed indent,
+and treegrid semantics

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -61216,6 +61216,15 @@
                 "text": "boolean"
               },
               "fieldName": "loading"
+            },
+            {
+              "name": "tree",
+              "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "tree"
             }
           ],
           "members": [
@@ -61282,6 +61291,17 @@
               },
               "readonly": true,
               "attribute": "loading"
+            },
+            {
+              "kind": "field",
+              "name": "tree",
+              "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "tree"
             },
             {
               "kind": "method",
@@ -61355,6 +61375,163 @@
           "customElement": true,
           "tagName": "swirl-table-cell",
           "name": "SwirlTableCell",
+          "attributes": [
+            {
+              "name": "collapsed-icon",
+              "description": "Glyph override for the collapsed toggle. Defaults to `chevron-right`.",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"chevron-right\"",
+              "fieldName": "collapsedIcon"
+            },
+            {
+              "name": "expandable",
+              "description": "When true, the cell has children and renders a toggle. When false, it is a\nleaf and content sits flush after the level indent (no toggle zone).",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "expandable"
+            },
+            {
+              "name": "expanded",
+              "description": "Open/closed state. Controlled by the consumer; ignored when not expandable.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "expanded"
+            },
+            {
+              "name": "expanded-icon",
+              "description": "Glyph override for the expanded toggle. Defaults to `expand-more`.",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"expand-more\"",
+              "fieldName": "expandedIcon"
+            },
+            {
+              "name": "label",
+              "description": "Accessible name of the tree node, used to build the toggle label\n(`Expand {label}` / `Collapse {label}`).",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "label"
+            },
+            {
+              "name": "level",
+              "description": "0-indexed depth. Drives computed inline-start indent when `tree` is true.",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "fieldName": "level"
+            },
+            {
+              "name": "tree",
+              "description": "Enable the tree affordance (indent + optional expand/collapse toggle).",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "tree"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "collapsedIcon",
+              "description": "Glyph override for the collapsed toggle. Defaults to `chevron-right`.",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"chevron-right\"",
+              "readonly": true,
+              "attribute": "collapsed-icon"
+            },
+            {
+              "kind": "field",
+              "name": "expandable",
+              "description": "When true, the cell has children and renders a toggle. When false, it is a\nleaf and content sits flush after the level indent (no toggle zone).",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "expandable"
+            },
+            {
+              "kind": "field",
+              "name": "expanded",
+              "description": "Open/closed state. Controlled by the consumer; ignored when not expandable.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "expanded"
+            },
+            {
+              "kind": "field",
+              "name": "expandedIcon",
+              "description": "Glyph override for the expanded toggle. Defaults to `expand-more`.",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"expand-more\"",
+              "readonly": true,
+              "attribute": "expanded-icon"
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "description": "Accessible name of the tree node, used to build the toggle label\n(`Expand {label}` / `Collapse {label}`).",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "level",
+              "description": "0-indexed depth. Drives computed inline-start indent when `tree` is true.",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "readonly": true,
+              "attribute": "level"
+            },
+            {
+              "kind": "field",
+              "name": "tree",
+              "description": "Enable the tree affordance (indent + optional expand/collapse toggle).",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "tree",
+              "reflects": true
+            }
+          ],
+          "events": [
+            {
+              "name": "toggle",
+              "description": "Emitted when the toggle is activated. The payload is the requested next\nstate. The component does not own expand state.",
+              "type": {
+                "text": "CustomEvent<{ expanded: boolean; }>",
+                "references": [
+                  {
+                    "name": "SwirlTableCellToggleEventDetail"
+                  }
+                ]
+              }
+            }
+          ],
           "slots": [
             {
               "name": "slot",
@@ -61577,6 +61754,48 @@
                 "text": "number"
               },
               "fieldName": "index"
+            },
+            {
+              "name": "tree-expandable",
+              "description": "Whether this row has children. When true, `aria-expanded` is set from\n`treeExpanded`.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "treeExpandable"
+            },
+            {
+              "name": "tree-expanded",
+              "description": "Whether this expandable row is currently expanded. Ignored when not\nexpandable.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "fieldName": "treeExpanded"
+            },
+            {
+              "name": "tree-level",
+              "description": "0-indexed tree depth. Mapped to 1-based `aria-level` for treegrid.",
+              "type": {
+                "text": "number"
+              },
+              "fieldName": "treeLevel"
+            },
+            {
+              "name": "tree-pos-inset",
+              "description": "1-based position among siblings. Mapped to `aria-posinset`.",
+              "type": {
+                "text": "number"
+              },
+              "fieldName": "treePosInset"
+            },
+            {
+              "name": "tree-set-size",
+              "description": "Number of siblings at this level. Mapped to `aria-setsize`.",
+              "type": {
+                "text": "number"
+              },
+              "fieldName": "treeSetSize"
             }
           ],
           "members": [
@@ -61597,6 +61816,58 @@
               },
               "readonly": true,
               "attribute": "index"
+            },
+            {
+              "kind": "field",
+              "name": "treeExpandable",
+              "description": "Whether this row has children. When true, `aria-expanded` is set from\n`treeExpanded`.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "tree-expandable"
+            },
+            {
+              "kind": "field",
+              "name": "treeExpanded",
+              "description": "Whether this expandable row is currently expanded. Ignored when not\nexpandable.",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "readonly": true,
+              "attribute": "tree-expanded"
+            },
+            {
+              "kind": "field",
+              "name": "treeLevel",
+              "description": "0-indexed tree depth. Mapped to 1-based `aria-level` for treegrid.",
+              "type": {
+                "text": "number"
+              },
+              "readonly": true,
+              "attribute": "tree-level"
+            },
+            {
+              "kind": "field",
+              "name": "treePosInset",
+              "description": "1-based position among siblings. Mapped to `aria-posinset`.",
+              "type": {
+                "text": "number"
+              },
+              "readonly": true,
+              "attribute": "tree-pos-inset"
+            },
+            {
+              "kind": "field",
+              "name": "treeSetSize",
+              "description": "Number of siblings at this level. Mapped to `aria-setsize`.",
+              "type": {
+                "text": "number"
+              },
+              "readonly": true,
+              "attribute": "tree-set-size"
             }
           ],
           "slots": [

--- a/packages/swirl-components/custom-elements.manifest.json
+++ b/packages/swirl-components/custom-elements.manifest.json
@@ -61198,6 +61198,7 @@
             },
             {
               "name": "enable-drag-drop",
+              "description": "Enables row drag and drop. Ignored when the table is in tree mode —\ncombining hierarchy with reorder is not supported.",
               "type": {
                 "text": "boolean"
               },
@@ -61219,7 +61220,7 @@
             },
             {
               "name": "tree",
-              "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute.",
+              "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute. Incompatible with `enableDragDrop`.",
               "type": {
                 "text": "boolean"
               },
@@ -61268,6 +61269,7 @@
             {
               "kind": "field",
               "name": "enableDragDrop",
+              "description": "Enables row drag and drop. Ignored when the table is in tree mode —\ncombining hierarchy with reorder is not supported.",
               "type": {
                 "text": "boolean"
               },
@@ -61295,7 +61297,7 @@
             {
               "kind": "field",
               "name": "tree",
-              "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute.",
+              "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute. Incompatible with `enableDragDrop`.",
               "type": {
                 "text": "boolean"
               },

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -75,6 +75,7 @@ import { SwirlTabBarJustify as SwirlTabBarJustify1, SwirlTabBarPadding as SwirlT
 import { SwirlTabPadding } from "./components/swirl-tab/swirl-tab";
 import { SwirlTabBarJustify, SwirlTabBarPadding, SwirlTabBarTab, SwirlTabBarVariant } from "./components/swirl-tab-bar/swirl-tab-bar";
 import { SwirlTableDropRowEvent } from "./components/swirl-table/swirl-table";
+import { SwirlTableCellToggleEventDetail } from "./components/swirl-table-cell/swirl-table-cell";
 import { SwirlTableColumnSort, SwirlTableColumnVariant } from "./components/swirl-table-column/swirl-table-column";
 import { SwirlTagIconPosition, SwirlTagIntent, SwirlTagSize, SwirlTagVariant } from "./components/swirl-tag/swirl-tag";
 import { SwirlTextAlign, SwirlTextColor, SwirlTextFontFamily, SwirlTextFontStyle, SwirlTextSize, SwirlTextTruncateDirection, SwirlTextWeight, SwirlTextWhiteSpace } from "./components/swirl-text/swirl-text";
@@ -159,6 +160,7 @@ export { SwirlTabBarJustify as SwirlTabBarJustify1, SwirlTabBarPadding as SwirlT
 export { SwirlTabPadding } from "./components/swirl-tab/swirl-tab";
 export { SwirlTabBarJustify, SwirlTabBarPadding, SwirlTabBarTab, SwirlTabBarVariant } from "./components/swirl-tab-bar/swirl-tab-bar";
 export { SwirlTableDropRowEvent } from "./components/swirl-table/swirl-table";
+export { SwirlTableCellToggleEventDetail } from "./components/swirl-table-cell/swirl-table-cell";
 export { SwirlTableColumnSort, SwirlTableColumnVariant } from "./components/swirl-table-column/swirl-table-column";
 export { SwirlTagIconPosition, SwirlTagIntent, SwirlTagSize, SwirlTagVariant } from "./components/swirl-tag/swirl-tag";
 export { SwirlTextAlign, SwirlTextColor, SwirlTextFontFamily, SwirlTextFontStyle, SwirlTextSize, SwirlTextTruncateDirection, SwirlTextWeight, SwirlTextWhiteSpace } from "./components/swirl-text/swirl-text";
@@ -5420,8 +5422,47 @@ export namespace Components {
           * Force a re-render of the table
          */
         "rerender": () => Promise<void>;
+        /**
+          * Enables treegrid semantics (`role="treegrid"`). Use with tree props on `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell has the `tree` attribute.
+          * @default false
+         */
+        "tree"?: boolean;
     }
     interface SwirlTableCell {
+        /**
+          * Glyph override for the collapsed toggle. Defaults to `chevron-right`.
+          * @default "chevron-right"
+         */
+        "collapsedIcon"?: string;
+        /**
+          * When true, the cell has children and renders a toggle. When false, it is a leaf and content sits flush after the level indent (no toggle zone).
+          * @default false
+         */
+        "expandable"?: boolean;
+        /**
+          * Open/closed state. Controlled by the consumer; ignored when not expandable.
+          * @default false
+         */
+        "expanded"?: boolean;
+        /**
+          * Glyph override for the expanded toggle. Defaults to `expand-more`.
+          * @default "expand-more"
+         */
+        "expandedIcon"?: string;
+        /**
+          * Accessible name of the tree node, used to build the toggle label (`Expand {label}` / `Collapse {label}`).
+         */
+        "label"?: string;
+        /**
+          * 0-indexed depth. Drives computed inline-start indent when `tree` is true.
+          * @default 0
+         */
+        "level"?: number;
+        /**
+          * Enable the tree affordance (indent + optional expand/collapse toggle).
+          * @default false
+         */
+        "tree"?: boolean;
     }
     interface SwirlTableColumn {
         "maxWidth"?: string;
@@ -5441,6 +5482,28 @@ export namespace Components {
     interface SwirlTableRow {
         "highlighted"?: boolean;
         "index"?: number;
+        /**
+          * Whether this row has children. When true, `aria-expanded` is set from `treeExpanded`.
+          * @default false
+         */
+        "treeExpandable"?: boolean;
+        /**
+          * Whether this expandable row is currently expanded. Ignored when not expandable.
+          * @default false
+         */
+        "treeExpanded"?: boolean;
+        /**
+          * 0-indexed tree depth. Mapped to 1-based `aria-level` for treegrid.
+         */
+        "treeLevel"?: number;
+        /**
+          * 1-based position among siblings. Mapped to `aria-posinset`.
+         */
+        "treePosInset"?: number;
+        /**
+          * Number of siblings at this level. Mapped to `aria-setsize`.
+         */
+        "treeSetSize"?: number;
     }
     interface SwirlTableRowGroup {
         /**
@@ -6090,6 +6153,10 @@ export interface SwirlTabBarCustomEvent<T> extends CustomEvent<T> {
 export interface SwirlTableCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSwirlTableElement;
+}
+export interface SwirlTableCellCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSwirlTableCellElement;
 }
 export interface SwirlTabsCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -9892,7 +9959,18 @@ declare global {
         prototype: HTMLSwirlTableElement;
         new (): HTMLSwirlTableElement;
     };
+    interface HTMLSwirlTableCellElementEventMap {
+        "toggle": SwirlTableCellToggleEventDetail;
+    }
     interface HTMLSwirlTableCellElement extends Components.SwirlTableCell, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSwirlTableCellElementEventMap>(type: K, listener: (this: HTMLSwirlTableCellElement, ev: SwirlTableCellCustomEvent<HTMLSwirlTableCellElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSwirlTableCellElementEventMap>(type: K, listener: (this: HTMLSwirlTableCellElement, ev: SwirlTableCellCustomEvent<HTMLSwirlTableCellElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLSwirlTableCellElement: {
         prototype: HTMLSwirlTableCellElement;
@@ -15833,8 +15911,51 @@ declare namespace LocalJSX {
         "label": string;
         "loading"?: boolean;
         "onDropRow"?: (event: SwirlTableCustomEvent<SwirlTableDropRowEvent>) => void;
+        /**
+          * Enables treegrid semantics (`role="treegrid"`). Use with tree props on `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell has the `tree` attribute.
+          * @default false
+         */
+        "tree"?: boolean;
     }
     interface SwirlTableCell {
+        /**
+          * Glyph override for the collapsed toggle. Defaults to `chevron-right`.
+          * @default "chevron-right"
+         */
+        "collapsedIcon"?: string;
+        /**
+          * When true, the cell has children and renders a toggle. When false, it is a leaf and content sits flush after the level indent (no toggle zone).
+          * @default false
+         */
+        "expandable"?: boolean;
+        /**
+          * Open/closed state. Controlled by the consumer; ignored when not expandable.
+          * @default false
+         */
+        "expanded"?: boolean;
+        /**
+          * Glyph override for the expanded toggle. Defaults to `expand-more`.
+          * @default "expand-more"
+         */
+        "expandedIcon"?: string;
+        /**
+          * Accessible name of the tree node, used to build the toggle label (`Expand {label}` / `Collapse {label}`).
+         */
+        "label"?: string;
+        /**
+          * 0-indexed depth. Drives computed inline-start indent when `tree` is true.
+          * @default 0
+         */
+        "level"?: number;
+        /**
+          * Emitted when the toggle is activated. The payload is the requested next state. The component does not own expand state.
+         */
+        "onToggle"?: (event: SwirlTableCellCustomEvent<SwirlTableCellToggleEventDetail>) => void;
+        /**
+          * Enable the tree affordance (indent + optional expand/collapse toggle).
+          * @default false
+         */
+        "tree"?: boolean;
     }
     interface SwirlTableColumn {
         "maxWidth"?: string;
@@ -15854,6 +15975,28 @@ declare namespace LocalJSX {
     interface SwirlTableRow {
         "highlighted"?: boolean;
         "index"?: number;
+        /**
+          * Whether this row has children. When true, `aria-expanded` is set from `treeExpanded`.
+          * @default false
+         */
+        "treeExpandable"?: boolean;
+        /**
+          * Whether this expandable row is currently expanded. Ignored when not expandable.
+          * @default false
+         */
+        "treeExpanded"?: boolean;
+        /**
+          * 0-indexed tree depth. Mapped to 1-based `aria-level` for treegrid.
+         */
+        "treeLevel"?: number;
+        /**
+          * 1-based position among siblings. Mapped to `aria-posinset`.
+         */
+        "treePosInset"?: number;
+        /**
+          * Number of siblings at this level. Mapped to `aria-setsize`.
+         */
+        "treeSetSize"?: number;
     }
     interface SwirlTableRowGroup {
         /**
@@ -18996,6 +19139,16 @@ declare namespace LocalJSX {
         "enableDragDrop": boolean;
         "label": string;
         "loading": boolean;
+        "tree": boolean;
+    }
+    interface SwirlTableCellAttributes {
+        "tree": boolean;
+        "level": number;
+        "expandable": boolean;
+        "expanded": boolean;
+        "label": string;
+        "collapsedIcon": string;
+        "expandedIcon": string;
     }
     interface SwirlTableColumnAttributes {
         "variant": SwirlTableColumnVariant;
@@ -19009,6 +19162,11 @@ declare namespace LocalJSX {
     interface SwirlTableRowAttributes {
         "highlighted": boolean;
         "index": number;
+        "treeLevel": number;
+        "treeExpandable": boolean;
+        "treeExpanded": boolean;
+        "treeSetSize": number;
+        "treePosInset": number;
     }
     interface SwirlTableRowGroupAttributes {
         "label": string;
@@ -19734,7 +19892,7 @@ declare namespace LocalJSX {
         "swirl-tab": Omit<SwirlTab, keyof SwirlTabAttributes> & { [K in keyof SwirlTab & keyof SwirlTabAttributes]?: SwirlTab[K] } & { [K in keyof SwirlTab & keyof SwirlTabAttributes as `attr:${K}`]?: SwirlTabAttributes[K] } & { [K in keyof SwirlTab & keyof SwirlTabAttributes as `prop:${K}`]?: SwirlTab[K] } & OneOf<"label", SwirlTab["label"], SwirlTabAttributes["label"]> & OneOf<"tabId", SwirlTab["tabId"], SwirlTabAttributes["tabId"]>;
         "swirl-tab-bar": Omit<SwirlTabBar, keyof SwirlTabBarAttributes> & { [K in keyof SwirlTabBar & keyof SwirlTabBarAttributes]?: SwirlTabBar[K] } & { [K in keyof SwirlTabBar & keyof SwirlTabBarAttributes as `attr:${K}`]?: SwirlTabBarAttributes[K] } & { [K in keyof SwirlTabBar & keyof SwirlTabBarAttributes as `prop:${K}`]?: SwirlTabBar[K] } & OneOf<"label", SwirlTabBar["label"], SwirlTabBarAttributes["label"]>;
         "swirl-table": Omit<SwirlTable, keyof SwirlTableAttributes> & { [K in keyof SwirlTable & keyof SwirlTableAttributes]?: SwirlTable[K] } & { [K in keyof SwirlTable & keyof SwirlTableAttributes as `attr:${K}`]?: SwirlTableAttributes[K] } & { [K in keyof SwirlTable & keyof SwirlTableAttributes as `prop:${K}`]?: SwirlTable[K] } & OneOf<"label", SwirlTable["label"], SwirlTableAttributes["label"]>;
-        "swirl-table-cell": SwirlTableCell;
+        "swirl-table-cell": Omit<SwirlTableCell, keyof SwirlTableCellAttributes> & { [K in keyof SwirlTableCell & keyof SwirlTableCellAttributes]?: SwirlTableCell[K] } & { [K in keyof SwirlTableCell & keyof SwirlTableCellAttributes as `attr:${K}`]?: SwirlTableCellAttributes[K] } & { [K in keyof SwirlTableCell & keyof SwirlTableCellAttributes as `prop:${K}`]?: SwirlTableCell[K] };
         "swirl-table-column": Omit<SwirlTableColumn, keyof SwirlTableColumnAttributes> & { [K in keyof SwirlTableColumn & keyof SwirlTableColumnAttributes]?: SwirlTableColumn[K] } & { [K in keyof SwirlTableColumn & keyof SwirlTableColumnAttributes as `attr:${K}`]?: SwirlTableColumnAttributes[K] } & { [K in keyof SwirlTableColumn & keyof SwirlTableColumnAttributes as `prop:${K}`]?: SwirlTableColumn[K] };
         "swirl-table-row": Omit<SwirlTableRow, keyof SwirlTableRowAttributes> & { [K in keyof SwirlTableRow & keyof SwirlTableRowAttributes]?: SwirlTableRow[K] } & { [K in keyof SwirlTableRow & keyof SwirlTableRowAttributes as `attr:${K}`]?: SwirlTableRowAttributes[K] } & { [K in keyof SwirlTableRow & keyof SwirlTableRowAttributes as `prop:${K}`]?: SwirlTableRow[K] };
         "swirl-table-row-group": Omit<SwirlTableRowGroup, keyof SwirlTableRowGroupAttributes> & { [K in keyof SwirlTableRowGroup & keyof SwirlTableRowGroupAttributes]?: SwirlTableRowGroup[K] } & { [K in keyof SwirlTableRowGroup & keyof SwirlTableRowGroupAttributes as `attr:${K}`]?: SwirlTableRowGroupAttributes[K] } & { [K in keyof SwirlTableRowGroup & keyof SwirlTableRowGroupAttributes as `prop:${K}`]?: SwirlTableRowGroup[K] } & OneOf<"label", SwirlTableRowGroup["label"], SwirlTableRowGroupAttributes["label"]>;

--- a/packages/swirl-components/src/components.d.ts
+++ b/packages/swirl-components/src/components.d.ts
@@ -5415,6 +5415,9 @@ export namespace Components {
           * @default "No results found."
          */
         "emptyStateLabel"?: string;
+        /**
+          * Enables row drag and drop. Ignored when the table is in tree mode — combining hierarchy with reorder is not supported.
+         */
         "enableDragDrop"?: boolean;
         "label": string;
         "loading"?: boolean;
@@ -5423,7 +5426,7 @@ export namespace Components {
          */
         "rerender": () => Promise<void>;
         /**
-          * Enables treegrid semantics (`role="treegrid"`). Use with tree props on `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell has the `tree` attribute.
+          * Enables treegrid semantics (`role="treegrid"`). Use with tree props on `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell has the `tree` attribute. Incompatible with `enableDragDrop`.
           * @default false
          */
         "tree"?: boolean;
@@ -15907,12 +15910,15 @@ declare namespace LocalJSX {
           * @default "No results found."
          */
         "emptyStateLabel"?: string;
+        /**
+          * Enables row drag and drop. Ignored when the table is in tree mode — combining hierarchy with reorder is not supported.
+         */
         "enableDragDrop"?: boolean;
         "label": string;
         "loading"?: boolean;
         "onDropRow"?: (event: SwirlTableCustomEvent<SwirlTableDropRowEvent>) => void;
         /**
-          * Enables treegrid semantics (`role="treegrid"`). Use with tree props on `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell has the `tree` attribute.
+          * Enables treegrid semantics (`role="treegrid"`). Use with tree props on `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell has the `tree` attribute. Incompatible with `enableDragDrop`.
           * @default false
          */
         "tree"?: boolean;

--- a/packages/swirl-components/src/components/swirl-link/swirl-link.css
+++ b/packages/swirl-components/src/components/swirl-link/swirl-link.css
@@ -11,10 +11,12 @@
 .link {
   color: var(--s-interactive-primary-default);
   line-height: var(--s-line-height-base);
+  text-decoration: var(--swirl-link-text-decoration, underline);
   text-underline-offset: var(--s-space-4);
 
   &:hover {
     color: var(--s-interactive-primary-hovered);
+    text-decoration: underline;
   }
 
   &:active {

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.css
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.css
@@ -20,6 +20,8 @@
   transition: box-shadow 0.15s;
 
   &(.table-cell--tree) {
+    /* Slotted swirl-link titles underline only on hover. */
+    --swirl-link-text-decoration: none;
     padding-left: calc(
       var(--s-space-16) + var(--swirl-table-cell-tree-level) *
         var(--swirl-table-cell-tree-indent-step)

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.css
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.css
@@ -1,4 +1,9 @@
 :host {
+  --swirl-table-cell-tree-indent-step: calc(
+    var(--s-space-24) + var(--s-space-12)
+  );
+  --swirl-table-cell-tree-level: 0;
+
   display: flex;
   overflow: auto;
   padding-top: var(--s-space-8);
@@ -13,6 +18,13 @@
   word-break: break-word;
   hyphens: auto;
   transition: box-shadow 0.15s;
+
+  &(.table-cell--tree) {
+    padding-left: calc(
+      var(--s-space-16) + var(--swirl-table-cell-tree-level) *
+        var(--swirl-table-cell-tree-indent-step)
+    );
+  }
 
   &(.table-cell--is-sticky) {
     position: sticky;
@@ -37,4 +49,50 @@
   & * {
     box-sizing: border-box;
   }
+}
+
+.table-cell__tree {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  width: 100%;
+}
+
+.table-cell__tree-toggle {
+  display: inline-flex;
+  margin: 0;
+  padding: 0;
+  flex: 0 0 var(--swirl-table-cell-tree-indent-step);
+  justify-content: center;
+  align-items: center;
+  width: var(--swirl-table-cell-tree-indent-step);
+  height: var(--swirl-table-cell-tree-indent-step);
+  border: none;
+  border-radius: var(--s-border-radius-sm);
+  color: var(--s-icon-default);
+  background-color: transparent;
+  cursor: pointer;
+  appearance: none;
+
+  &:hover {
+    background-color: var(--s-state-hovered);
+  }
+
+  &:active {
+    background-color: var(--s-state-pressed);
+  }
+
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline-color: var(--s-focus-default);
+    outline-offset: var(--s-space-2);
+  }
+}
+
+.table-cell__tree-content {
+  min-width: 0;
+  flex: 1 1 auto;
 }

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.css
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.css
@@ -54,6 +54,7 @@
 .table-cell__tree {
   display: flex;
   min-width: 0;
+  flex: 1 1 auto;
   align-items: center;
   width: 100%;
 }

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.mdx
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.mdx
@@ -21,6 +21,22 @@ The SwirlTableColumn component is used to display a cell inside a
 
 <Source code={`<swirl-table-cell> Table cell </swirl-table-cell>`} />
 
+## Tree cell
+
+Set `tree` on the first data column to add computed indent and, when
+`expandable`, a focusable expand/collapse toggle. Slot the cell content (for
+example a link plus a subdued description). The consumer owns expand state and
+reacts to `toggle`.
+
+<Source
+  code={`<swirl-table-cell tree level="1" expandable expanded label="Platform">
+  <swirl-stack spacing="0">
+    <swirl-link href="#" label="Platform"></swirl-link>
+    <swirl-text color="subdued" size="sm">Shared infrastructure</swirl-text>
+  </swirl-stack>
+</swirl-table-cell>`}
+/>
+
 ## Related components
 
 - **[swirl-table-row](?path=/docs/components-swirltablerow--docs)** (parent) —
@@ -33,10 +49,13 @@ The SwirlTableColumn component is used to display a cell inside a
 The component follows the
 [WAI-ARIA Table Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/).
 
-| ARIA          | Usage |
-| ------------- | ----- |
-| `role="cell"` |       |
+| ARIA            | Usage                                                |
+| --------------- | ---------------------------------------------------- |
+| `role="cell"`   |                                                      |
+| `aria-expanded` | Set on the tree toggle button when `expandable`.     |
+| `aria-label`    | `Expand {label}` / `Collapse {label}` on the toggle. |
 
 ### Keyboard
 
-No component-specific keyboard behavior.
+When `tree` and `expandable` are set, the toggle is a `<button>`. Enter and
+Space activate it and emit `toggle`. Focus-visible uses `--s-focus-default`.

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.mdx
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.mdx
@@ -24,9 +24,12 @@ The SwirlTableColumn component is used to display a cell inside a
 ## Tree cell
 
 Set `tree` on the first data column to add computed indent and, when
-`expandable`, a focusable expand/collapse toggle. Slot the cell content (for
-example a link plus a subdued description). The consumer owns expand state and
-reacts to `toggle`.
+`expandable`, a focusable expand/collapse toggle. Slot the cell content. The
+consumer owns expand state and reacts to `toggle`.
+
+Use a **link** when the title opens details (`swirl-link`, highlight color,
+underline on hover only) or **plain text** when it does not (`swirl-text`,
+default color, no underline).
 
 <Source
   code={`<swirl-table-cell tree level="1" expandable expanded label="Platform">
@@ -34,8 +37,17 @@ reacts to `toggle`.
     <swirl-link href="#" label="Platform"></swirl-link>
     <swirl-text color="subdued" size="sm">Shared infrastructure</swirl-text>
   </swirl-stack>
-</swirl-table-cell>`}
-/>
+</swirl-table-cell>
+
+<swirl-table-cell tree level="1" label="Legal">
+  <swirl-stack spacing="0">
+    <swirl-text size="sm">Legal</swirl-text>
+    <swirl-text color="subdued" size="sm">
+      Leaf at the root
+    </swirl-text>
+  </swirl-stack>
+</swirl-table-cell>
+`} />
 
 ## Related components
 

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.spec.tsx
@@ -18,4 +18,94 @@ describe("swirl-table-cell", () => {
       </swirl-table-cell>
     `);
   });
+
+  it("indents tree cells by level", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableCell],
+      html: `<swirl-table-cell tree level="3">Cell</swirl-table-cell>`,
+    });
+
+    expect(page.root).toHaveClass("table-cell--tree");
+    expect(
+      page.root.style.getPropertyValue("--swirl-table-cell-tree-level")
+    ).toBe("3");
+
+    page.root.level = 0;
+    await page.waitForChanges();
+
+    expect(
+      page.root.style.getPropertyValue("--swirl-table-cell-tree-level")
+    ).toBe("0");
+  });
+
+  it("renders a focusable toggle for expandable rows and emits toggle", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableCell],
+      html: `<swirl-table-cell tree expandable label="Engineering">Cell</swirl-table-cell>`,
+    });
+
+    const spy = jest.fn();
+
+    page.root.addEventListener("toggle", spy);
+
+    const toggle = page.root.shadowRoot.querySelector<HTMLButtonElement>(
+      ".table-cell__tree-toggle"
+    );
+
+    expect(toggle).toBeTruthy();
+    expect(toggle.getAttribute("aria-label")).toBe("Expand Engineering");
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle.querySelector("swirl-icon")?.getAttribute("glyph")).toBe(
+      "chevron-right"
+    );
+
+    toggle.click();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toEqual({ expanded: true });
+
+    page.root.expanded = true;
+    await page.waitForChanges();
+
+    expect(toggle.getAttribute("aria-label")).toBe("Collapse Engineering");
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(toggle.querySelector("swirl-icon")?.getAttribute("glyph")).toBe(
+      "expand-more"
+    );
+
+    toggle.click();
+
+    expect(spy.mock.calls[1][0].detail).toEqual({ expanded: false });
+  });
+
+  it("renders no toggle for leaf cells", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableCell],
+      html: `<swirl-table-cell tree level="1">Leaf</swirl-table-cell>`,
+    });
+
+    expect(
+      page.root.shadowRoot.querySelector(".table-cell__tree-toggle")
+    ).toBeNull();
+    expect(page.root).not.toHaveClass("table-cell--tree-expandable");
+    expect(
+      page.root.shadowRoot.querySelector(".table-cell__tree-content")
+    ).toBeTruthy();
+  });
+
+  it("allows icon overrides", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableCell],
+      html: `<swirl-table-cell tree expandable collapsed-icon="folder" expanded-icon="folder-open">Cell</swirl-table-cell>`,
+    });
+
+    const icon = page.root.shadowRoot.querySelector("swirl-icon");
+
+    expect(icon.getAttribute("glyph")).toBe("folder");
+
+    page.root.expanded = true;
+    await page.waitForChanges();
+
+    expect(icon.getAttribute("glyph")).toBe("folder-open");
+  });
 });

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.spec.tsx
@@ -78,6 +78,17 @@ describe("swirl-table-cell", () => {
     expect(spy.mock.calls[1][0].detail).toEqual({ expanded: false });
   });
 
+  it("hides link underlines until hover in tree cells", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableCell],
+      html: `<swirl-table-cell tree expandable label="Group">Cell</swirl-table-cell>`,
+    });
+
+    expect(
+      page.root.style.getPropertyValue("--swirl-link-text-decoration")
+    ).toBe("none");
+  });
+
   it("renders no toggle for leaf cells", async () => {
     const page = await newSpecPage({
       components: [SwirlTableCell],

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.tsx
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.tsx
@@ -1,4 +1,18 @@
-import { Component, h, Host } from "@stencil/core";
+import {
+  Component,
+  Element,
+  Event,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+  Watch,
+} from "@stencil/core";
+import classnames from "classnames";
+
+export type SwirlTableCellToggleEventDetail = {
+  expanded: boolean;
+};
 
 /**
  * @slot slot - The cell content.
@@ -9,10 +23,125 @@ import { Component, h, Host } from "@stencil/core";
   tag: "swirl-table-cell",
 })
 export class SwirlTableCell {
+  @Element() el: HTMLElement;
+
+  /**
+   * Enable the tree affordance (indent + optional expand/collapse toggle).
+   */
+  @Prop({ reflect: true }) tree?: boolean = false;
+
+  /**
+   * 0-indexed depth. Drives computed inline-start indent when `tree` is true.
+   */
+  @Prop() level?: number = 0;
+
+  /**
+   * When true, the cell has children and renders a toggle. When false, it is a
+   * leaf and content sits flush after the level indent (no toggle zone).
+   */
+  @Prop() expandable?: boolean = false;
+
+  /**
+   * Open/closed state. Controlled by the consumer; ignored when not expandable.
+   */
+  @Prop() expanded?: boolean = false;
+
+  /**
+   * Accessible name of the tree node, used to build the toggle label
+   * (`Expand {label}` / `Collapse {label}`).
+   */
+  @Prop() label?: string;
+
+  /**
+   * Glyph override for the collapsed toggle. Defaults to `chevron-right`.
+   */
+  @Prop() collapsedIcon?: string = "chevron-right";
+
+  /**
+   * Glyph override for the expanded toggle. Defaults to `expand-more`.
+   */
+  @Prop() expandedIcon?: string = "expand-more";
+
+  /**
+   * Emitted when the toggle is activated. The payload is the requested next
+   * state. The component does not own expand state.
+   */
+  @Event() toggle: EventEmitter<SwirlTableCellToggleEventDetail>;
+
+  componentWillLoad() {
+    this.updateTreeLevel();
+  }
+
+  @Watch("tree")
+  @Watch("level")
+  watchTreeIndent() {
+    this.updateTreeLevel();
+  }
+
+  private updateTreeLevel() {
+    if (this.tree) {
+      this.el.style.setProperty(
+        "--swirl-table-cell-tree-level",
+        String(this.level ?? 0)
+      );
+    } else {
+      this.el.style.removeProperty("--swirl-table-cell-tree-level");
+    }
+  }
+
+  private getToggleLabel() {
+    const action = this.expanded ? "Collapse" : "Expand";
+
+    return this.label ? `${action} ${this.label}` : action;
+  }
+
+  private onToggleClick = (event: MouseEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.toggle.emit({ expanded: !this.expanded });
+  };
+
   render() {
+    const className = classnames("table-cell", {
+      "table-cell--tree": this.tree,
+      "table-cell--tree-expandable": this.tree && this.expandable,
+    });
+
+    if (!this.tree) {
+      return (
+        <Host class={className} role="cell">
+          <slot></slot>
+        </Host>
+      );
+    }
+
+    const glyph = this.expanded
+      ? this.expandedIcon ?? "expand-more"
+      : this.collapsedIcon ?? "chevron-right";
+
     return (
-      <Host class="table-cell" role="cell">
-        <slot></slot>
+      <Host class={className} role="cell">
+        <div class="table-cell__tree">
+          {this.expandable && (
+            <button
+              aria-expanded={String(Boolean(this.expanded))}
+              aria-label={this.getToggleLabel()}
+              class="table-cell__tree-toggle"
+              onClick={this.onToggleClick}
+              type="button"
+            >
+              <swirl-icon
+                aria-hidden="true"
+                glyph={glyph}
+                size={24}
+              ></swirl-icon>
+            </button>
+          )}
+          <div class="table-cell__tree-content">
+            <slot></slot>
+          </div>
+        </div>
       </Host>
     );
   }

--- a/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.tsx
+++ b/packages/swirl-components/src/components/swirl-table-cell/swirl-table-cell.tsx
@@ -84,8 +84,10 @@ export class SwirlTableCell {
         "--swirl-table-cell-tree-level",
         String(this.level ?? 0)
       );
+      this.el.style.setProperty("--swirl-link-text-decoration", "none");
     } else {
       this.el.style.removeProperty("--swirl-table-cell-tree-level");
+      this.el.style.removeProperty("--swirl-link-text-decoration");
     }
   }
 

--- a/packages/swirl-components/src/components/swirl-table-row/swirl-table-row.mdx
+++ b/packages/swirl-components/src/components/swirl-table-row/swirl-table-row.mdx
@@ -49,7 +49,12 @@ The component follows the
 | --------------- | ----------------------------------------------------- |
 | `role="row"`    |                                                       |
 | `aria-rowindex` | Set to the overall index of the row inside the table. |
+| `aria-level`    | Tree depth when `treeLevel` is set (1-based).         |
+| `aria-expanded` | Set when `treeExpandable` is true.                    |
+| `aria-setsize`  | Set from `treeSetSize`.                               |
+| `aria-posinset` | Set from `treePosInset`.                              |
 
 ### Keyboard
 
-No component-specific keyboard behavior.
+No component-specific keyboard behavior. Expand/collapse is handled by the tree
+toggle in `swirl-table-cell`.

--- a/packages/swirl-components/src/components/swirl-table-row/swirl-table-row.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-table-row/swirl-table-row.spec.tsx
@@ -1,0 +1,52 @@
+import { newSpecPage } from "@stencil/core/testing";
+
+import { SwirlTableRow } from "./swirl-table-row";
+
+(global as any).IntersectionObserver = class {
+  constructor() {}
+  disconnect() {}
+  observe() {}
+};
+
+describe("swirl-table-row", () => {
+  it("renders its cells", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableRow],
+      html: `<swirl-table-row><span>Cell</span></swirl-table-row>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+      <swirl-table-row class="table-row" role="row">
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+        <span>
+          Cell
+        </span>
+      </swirl-table-row>
+    `);
+  });
+
+  it("sets treegrid ARIA attributes", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableRow],
+      html: `<swirl-table-row tree-level="2" tree-expandable tree-expanded tree-set-size="4" tree-pos-inset="3"></swirl-table-row>`,
+    });
+
+    expect(page.root.getAttribute("role")).toBe("row");
+    expect(page.root.getAttribute("aria-level")).toBe("3");
+    expect(page.root.getAttribute("aria-expanded")).toBe("true");
+    expect(page.root.getAttribute("aria-setsize")).toBe("4");
+    expect(page.root.getAttribute("aria-posinset")).toBe("3");
+  });
+
+  it("omits aria-expanded for leaf rows", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTableRow],
+      html: `<swirl-table-row tree-level="0" tree-set-size="2" tree-pos-inset="1"></swirl-table-row>`,
+    });
+
+    expect(page.root.getAttribute("aria-level")).toBe("1");
+    expect(page.root.getAttribute("aria-expanded")).toBeNull();
+  });
+});

--- a/packages/swirl-components/src/components/swirl-table-row/swirl-table-row.tsx
+++ b/packages/swirl-components/src/components/swirl-table-row/swirl-table-row.tsx
@@ -16,6 +16,33 @@ export class SwirlTableRow {
   @Prop() highlighted?: boolean;
   @Prop() index?: number;
 
+  /**
+   * 0-indexed tree depth. Mapped to 1-based `aria-level` for treegrid.
+   */
+  @Prop() treeLevel?: number;
+
+  /**
+   * Whether this row has children. When true, `aria-expanded` is set from
+   * `treeExpanded`.
+   */
+  @Prop() treeExpandable?: boolean = false;
+
+  /**
+   * Whether this expandable row is currently expanded. Ignored when not
+   * expandable.
+   */
+  @Prop() treeExpanded?: boolean = false;
+
+  /**
+   * Number of siblings at this level. Mapped to `aria-setsize`.
+   */
+  @Prop() treeSetSize?: number;
+
+  /**
+   * 1-based position among siblings. Mapped to `aria-posinset`.
+   */
+  @Prop() treePosInset?: number;
+
   componentDidLoad() {
     const table = closestPassShadow(this.el, "swirl-table");
 
@@ -27,8 +54,21 @@ export class SwirlTableRow {
       "table-row--highlighted": this.highlighted,
     });
 
+    const ariaLevel =
+      this.treeLevel === undefined ? undefined : this.treeLevel + 1;
+
     return (
-      <Host aria-rowindex={this.index} class={className} role="row">
+      <Host
+        aria-expanded={
+          this.treeExpandable ? String(Boolean(this.treeExpanded)) : undefined
+        }
+        aria-level={ariaLevel}
+        aria-posinset={this.treePosInset}
+        aria-rowindex={this.index}
+        aria-setsize={this.treeSetSize}
+        class={className}
+        role="row"
+      >
         <slot></slot>
       </Host>
     );

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.mdx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.mdx
@@ -143,6 +143,95 @@ The SwirlTable component is used to organize and display data sets.
 </swirl-table>`}
 />
 
+## Tree view
+
+`swirl-table` can render hierarchical data as a **treegrid**: rows stay **flat
+siblings**, and indentation is computed from each row's `level`. The table does
+not nest rows (that would break column alignment) and does **not** reuse
+`swirl-tree-view` / `swirl-tree-view-item` DOM.
+
+<Canvas of={Stories.TreeView}></Canvas>
+
+<Canvas of={Stories.TreeViewWithSelection}></Canvas>
+
+### Flat rows + computed indent
+
+- Each `swirl-table-row` is a sibling of the others. The consumer decides which
+  rows exist and which are visible.
+- `swirl-table-cell` `level` is **0-indexed**. Indent is
+  `level * (space-24 + space-12)` (36px) **in addition to** the cell's 16px base
+  inline padding.
+- The 36px step matches the toggle-zone width, so a leaf at level N lines up
+  with its parent's label at level N-1.
+- Leaves (`expandable` is false) render **no toggle** and no toggle-zone
+  padding.
+
+### State ownership
+
+The primitive is **presentational and controlled**. It does not fetch children,
+hide rows, or store expand state. Listen for `toggle` on `swirl-table-cell` and
+update your data (`expanded`, visible rows, `level`).
+
+### API
+
+**`swirl-table`**
+
+| Prop   | Notes                                                                  |
+| ------ | ---------------------------------------------------------------------- |
+| `tree` | Sets `role="treegrid"` on the table. Also inferred from a `tree` cell. |
+
+**`swirl-table-cell`** (tree column only)
+
+| Prop / event                     | Notes                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------ |
+| `tree`                           | Enables indent + optional toggle.                                        |
+| `level`                          | 0-indexed depth.                                                         |
+| `expandable` / `expanded`        | Parent vs leaf; `expanded` is ignored on leaves.                         |
+| `label`                          | Used for the toggle name: `Expand {label}` / `Collapse {label}`.         |
+| `collapsedIcon` / `expandedIcon` | Defaults `chevron-right` / `expand-more` (same vocabulary as tree view). |
+| `toggle`                         | `{ expanded: boolean }` — the requested next state.                      |
+
+**`swirl-table-row`** (ARIA)
+
+| Prop             | Maps to                                             |
+| ---------------- | --------------------------------------------------- |
+| `treeLevel`      | `aria-level` (0-indexed → 1-based)                  |
+| `treeExpandable` | When true, sets `aria-expanded` from `treeExpanded` |
+| `treeExpanded`   | `aria-expanded`                                     |
+| `treeSetSize`    | `aria-setsize`                                      |
+| `treePosInset`   | `aria-posinset`                                     |
+
+### Reuse boundary vs `swirl-tree-view`
+
+Reuse the **toggle icon names**, ARIA vocabulary, and tokens from
+`swirl-tree-view-item`. Do not nest table rows inside a parent row and do not
+route the table through `swirl-tree-view`.
+
+### Sample usage
+
+<Source
+  code={`<swirl-table label="Groups" tree>
+  <div slot="columns">
+    <swirl-table-column min-width="280px">Tree</swirl-table-column>
+    <swirl-table-column>Members</swirl-table-column>
+  </div>
+  <div slot="rows">
+    <swirl-table-row id="engineering" tree-level="0" tree-expandable tree-expanded tree-set-size="2" tree-pos-inset="1">
+      <swirl-table-cell tree level="0" expandable expanded label="Engineering">
+        <swirl-link href="#" label="Engineering"></swirl-link>
+      </swirl-table-cell>
+      <swirl-table-cell>128</swirl-table-cell>
+    </swirl-table-row>
+    <swirl-table-row id="product" tree-level="1" tree-set-size="1" tree-pos-inset="1">
+      <swirl-table-cell tree level="1" label="Product">
+        <swirl-link href="#" label="Product"></swirl-link>
+      </swirl-table-cell>
+      <swirl-table-cell>9</swirl-table-cell>
+    </swirl-table-row>
+  </div>
+</swirl-table>`}
+/>
+
 ## Related components
 
 - **[swirl-table-column](?path=/docs/components-swirltablecolumn--docs)**
@@ -158,11 +247,15 @@ The SwirlTable component is used to organize and display data sets.
 ### ARIA
 
 The component follows the
-[WAI-ARIA Table Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/).
+[WAI-ARIA Table Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/table/). When
+`tree` is set (or a tree cell is present) it follows the
+[WAI-ARIA Treegrid Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treegrid/)
+for roles and row state.
 
 | ARIA                  | Usage                                                           |
 | --------------------- | --------------------------------------------------------------- |
-| `role="table"`        | Set on the outer table element.                                 |
+| `role="table"`        | Set on the outer table element when tree mode is off.           |
+| `role="treegrid"`     | Set on the outer table element when tree mode is on.            |
 | `aria-rowcount`       | Set to the overall row count.                                   |
 | `aria-label`          | An accessible label is provided via the `aria-label` attribute. |
 | `role="rowgroup"`     | Set on the table's header and body elements.                    |
@@ -170,9 +263,16 @@ The component follows the
 | `aria-sort`           | Set on a sorted table column.                                   |
 | `role="row"`          | Set on a the table's row elements.                              |
 | `aria-rowindex`       | Set to the overall index of the row element.                    |
+| `aria-level`          | Tree depth of the row (1-based).                                |
+| `aria-expanded`       | Set on expandable tree rows.                                    |
+| `aria-setsize`        | Sibling count at the row's level.                               |
+| `aria-posinset`       | 1-based position among siblings.                                |
 | `role="cell"`         | Set on a the table's cell elements.                             |
 
 ### Keyboard
 
-No component-specific keyboard behavior; table navigation depends on host or
-application.
+Non-tree tables have no component-specific keyboard behavior.
+
+In tree mode, the expand/collapse control is a real `<button>`. Enter and Space
+activate it and emit `toggle`. Full treegrid arrow-key navigation (move between
+rows/cells, Left/Right to collapse/expand) is out of scope for v1.

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.mdx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.mdx
@@ -154,6 +154,37 @@ not nest rows (that would break column alignment) and does **not** reuse
 
 <Canvas of={Stories.TreeViewWithSelection}></Canvas>
 
+<Canvas of={Stories.TreeViewLabelVariants}></Canvas>
+
+### Clickable vs plain titles
+
+Slot the title yourself. The cell only provides indent and the toggle.
+
+- **Clickable:** slot a `swirl-link`. Color is `interactive-primary` /
+  highlight. Links inside a tree cell have **no underline until hover**.
+- **Plain text:** slot `swirl-text` (default color). No underline on hover.
+
+<Source
+  code={`<!-- Clickable title -->
+<swirl-table-cell tree level="0" expandable label="Engineering">
+  <swirl-stack spacing="0">
+    <swirl-link href="/groups/engineering" label="Engineering"></swirl-link>
+    <swirl-text color="subdued" size="sm">Platform and product delivery</swirl-text>
+  </swirl-stack>
+</swirl-table-cell>
+
+<!-- Plain title -->
+
+<swirl-table-cell tree level="0" expandable label="Legal">
+  <swirl-stack spacing="0">
+    <swirl-text size="sm">Legal</swirl-text>
+    <swirl-text color="subdued" size="sm">
+      Leaf at the root
+    </swirl-text>
+  </swirl-stack>
+</swirl-table-cell>
+`} />
+
 ### Flat rows + computed indent
 
 - Each `swirl-table-row` is a sibling of the others. The consumer decides which

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.mdx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.mdx
@@ -203,13 +203,17 @@ The primitive is **presentational and controlled**. It does not fetch children,
 hide rows, or store expand state. Listen for `toggle` on `swirl-table-cell` and
 update your data (`expanded`, visible rows, `level`).
 
+Tree mode and `enableDragDrop` cannot be combined. If both are set, drag and
+drop is ignored.
+
 ### API
 
 **`swirl-table`**
 
-| Prop   | Notes                                                                  |
-| ------ | ---------------------------------------------------------------------- |
-| `tree` | Sets `role="treegrid"` on the table. Also inferred from a `tree` cell. |
+| Prop              | Notes                                                                                          |
+| ----------------- | ---------------------------------------------------------------------------------------------- |
+| `tree`            | Sets `role="treegrid"` on the table. Also inferred from a `tree` cell.                         |
+| `enableDragDrop`  | Row reorder. **Not available in tree mode** — hierarchy plus drag-and-drop is too complex yet. |
 
 **`swirl-table-cell`** (tree column only)
 

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.spec.tsx
@@ -81,4 +81,26 @@ describe("swirl-table", () => {
       </swirl-table>
     `);
   });
+
+  it("uses treegrid semantics when tree mode is enabled", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTable],
+      html: `
+        <swirl-table label="Groups" tree>
+          <div slot="columns">
+            <span role="columnheader">Tree</span>
+          </div>
+          <div slot="rows">
+            <div role="row">
+              <span role="cell">Root</span>
+            </div>
+          </div>
+        </swirl-table>
+      `,
+    });
+
+    expect(page.root.querySelector(".table__table").getAttribute("role")).toBe(
+      "treegrid"
+    );
+  });
 });

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.spec.tsx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.spec.tsx
@@ -103,4 +103,34 @@ describe("swirl-table", () => {
       "treegrid"
     );
   });
+
+  it("ignores drag and drop when tree mode is enabled", async () => {
+    const page = await newSpecPage({
+      components: [SwirlTable],
+      html: `
+        <swirl-table
+          label="Groups"
+          tree
+          enable-drag-drop
+          drag-drop-handle=".drag-handle"
+        >
+          <div slot="columns">
+            <span role="columnheader">Tree</span>
+          </div>
+          <div slot="rows">
+            <div role="row">
+              <span role="cell">Root</span>
+            </div>
+          </div>
+        </swirl-table>
+      `,
+    });
+
+    expect(
+      page.root.querySelector(".table > swirl-visually-hidden [aria-live]")
+    ).toBeNull();
+    expect(page.root.querySelector(".table__table").getAttribute("role")).toBe(
+      "treegrid"
+    );
+  });
 });

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -412,7 +412,7 @@ const createTreeTable = (withSelection: boolean) => {
       </swirl-table-column>`
           : ""
       }
-      <swirl-table-column min-width="280px" sticky>Tree</swirl-table-column>
+      <swirl-table-column min-width="360px" sticky>Tree</swirl-table-column>
       <swirl-table-column min-width="100px">Members</swirl-table-column>
       <swirl-table-column min-width="120px">Status</swirl-table-column>
     </div>

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -1,32 +1,53 @@
 import { generateStoryElement } from "../../utils";
 import Docs from "./swirl-table.mdx";
 
+const dragDropControlIf = { arg: "tree", truthy: false };
+
+const tableControlOrder = [
+  "caption",
+  "label",
+  "emptyStateLabel",
+  "tree",
+  "enableDragDrop",
+  "dragDropHandle",
+  "dragDropInstructions",
+  "loading",
+];
+
 export default {
   argTypes: {
-    dragDropHandle: {
-      description:
-        'CSS selector for the drag handle. Needs to be set when "enableDragDrop" is true. The handle should be a button.',
-      if: { arg: "tree", truthy: false },
-    },
-    dragDropInstructions: {
-      if: { arg: "tree", truthy: false },
-    },
-    enableDragDrop: {
-      description:
-        "Enables row drag and drop. Hidden when tree mode is on — the two cannot be combined.",
-      if: { arg: "tree", truthy: false },
-    },
+    caption: {},
+    label: {},
+    emptyStateLabel: {},
     tree: {
       control: "boolean",
       description:
         "Renders the table as a treegrid. Disables drag and drop while enabled.",
     },
+    enableDragDrop: {
+      description:
+        "Enables row drag and drop. Hidden when tree mode is on — the two cannot be combined.",
+      if: dragDropControlIf,
+    },
+    dragDropHandle: {
+      description:
+        'CSS selector for the drag handle. Needs to be set when "enableDragDrop" is true. The handle should be a button.',
+      if: dragDropControlIf,
+    },
+    dragDropInstructions: {
+      if: dragDropControlIf,
+    },
+    loading: {},
   },
   component: "swirl-table",
   tags: ["autodocs"],
   parameters: {
     docs: {
       page: Docs,
+    },
+    controls: {
+      include: tableControlOrder,
+      sort: "none",
     },
   },
   title: "Components/SwirlTable",
@@ -597,18 +618,18 @@ export const SwirlTable = Template.bind({});
 
 SwirlTable.args = {
   caption: "A table displaying data.",
-  dragDropHandle: ".drag-handle",
-  enableDragDrop: true,
   label: "Table",
   tree: false,
+  enableDragDrop: true,
+  dragDropHandle: ".drag-handle",
 };
 
 const treeViewArgs = {
   caption: "A hierarchical table rendered as a treegrid.",
-  dragDropHandle: ".drag-handle",
-  enableDragDrop: false,
   label: "Groups",
   tree: true,
+  enableDragDrop: false,
+  dragDropHandle: ".drag-handle",
 };
 
 export const TreeView = (args) => createTreeTable(false, args);

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -160,6 +160,8 @@ type TreeNode = {
   description: string;
   members: string;
   status: "Active" | "Pending";
+  /** When set, the title is a link (highlight color, underline on hover). */
+  href?: string;
   children?: TreeNode[];
 };
 
@@ -170,6 +172,7 @@ const TREE_NODES: TreeNode[] = [
     description: "Platform and product delivery",
     members: "128",
     status: "Active",
+    href: "#",
     children: [
       {
         id: "platform",
@@ -177,6 +180,7 @@ const TREE_NODES: TreeNode[] = [
         description: "Shared infrastructure",
         members: "42",
         status: "Active",
+        href: "#",
         children: [
           {
             id: "frontend",
@@ -184,6 +188,7 @@ const TREE_NODES: TreeNode[] = [
             description: "Web applications",
             members: "18",
             status: "Active",
+            href: "#",
             children: [
               {
                 id: "design-system",
@@ -191,6 +196,7 @@ const TREE_NODES: TreeNode[] = [
                 description: "Swirl components",
                 members: "7",
                 status: "Active",
+                href: "#",
                 children: [
                   {
                     id: "tokens",
@@ -205,6 +211,7 @@ const TREE_NODES: TreeNode[] = [
                     description: "Web component library",
                     members: "4",
                     status: "Active",
+                    href: "#",
                     children: [
                       {
                         id: "buttons",
@@ -230,6 +237,7 @@ const TREE_NODES: TreeNode[] = [
                 description: "Closed parent",
                 members: "11",
                 status: "Pending",
+                href: "#",
                 children: [
                   {
                     id: "web-app-core",
@@ -248,6 +256,7 @@ const TREE_NODES: TreeNode[] = [
             description: "Closed parent",
             members: "16",
             status: "Active",
+            href: "#",
             children: [
               {
                 id: "api",
@@ -275,6 +284,7 @@ const TREE_NODES: TreeNode[] = [
     description: "Closed root",
     members: "24",
     status: "Pending",
+    href: "#",
     children: [
       {
         id: "brand",
@@ -370,7 +380,11 @@ const renderTreeRow = (row: FlatTreeRow, withSelection: boolean) => `
       label="${row.label}"
     >
       <swirl-stack spacing="0">
-        <swirl-link href="#" label="${row.label}"></swirl-link>
+        ${
+          row.href
+            ? `<swirl-link href="${row.href}" label="${row.label}"></swirl-link>`
+            : `<swirl-text size="sm">${row.label}</swirl-text>`
+        }
         <swirl-text color="subdued" size="sm">${row.description}</swirl-text>
       </swirl-stack>
     </swirl-table-cell>
@@ -521,6 +535,49 @@ TreeViewWithSelection.parameters = {
     description: {
       story:
         "Tree cells coexist with row-selection checkboxes. Descendant selection is owned by the consumer, not the table primitive.",
+    },
+  },
+};
+
+export const TreeViewLabelVariants = () => {
+  const element = generateStoryElement("swirl-table", {
+    caption: "Clickable and plain tree titles.",
+    label: "Tree label variants",
+    tree: true,
+  }) as HTMLSwirlTableElement;
+
+  element.innerHTML = `
+    <div slot="columns">
+      <swirl-table-column min-width="360px">Tree</swirl-table-column>
+    </div>
+    <div slot="rows">
+      <swirl-table-row id="clickable" tree-level="0" tree-expandable tree-set-size="2" tree-pos-inset="1">
+        <swirl-table-cell tree level="0" expandable label="Clickable element">
+          <swirl-stack spacing="0">
+            <swirl-link href="#" label="Clickable element"></swirl-link>
+            <swirl-text color="subdued" size="sm">Description of the link</swirl-text>
+          </swirl-stack>
+        </swirl-table-cell>
+      </swirl-table-row>
+      <swirl-table-row id="plain" tree-level="0" tree-expandable tree-set-size="2" tree-pos-inset="2">
+        <swirl-table-cell tree level="0" expandable label="Plain text element">
+          <swirl-stack spacing="0">
+            <swirl-text size="sm">Plain text element</swirl-text>
+            <swirl-text color="subdued" size="sm">Description of the item</swirl-text>
+          </swirl-stack>
+        </swirl-table-cell>
+      </swirl-table-row>
+    </div>
+  `;
+
+  return element;
+};
+
+TreeViewLabelVariants.parameters = {
+  docs: {
+    description: {
+      story:
+        "Slot a swirl-link for a clickable title (highlight color, underline on hover only) or swirl-text for a plain title (default color, no underline).",
     },
   },
 };

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -153,3 +153,355 @@ SwirlTable.args = {
   enableDragDrop: true,
   label: "Table",
 };
+
+type TreeNode = {
+  id: string;
+  label: string;
+  description: string;
+  members: string;
+  status: "Active" | "Pending";
+  children?: TreeNode[];
+};
+
+const TREE_NODES: TreeNode[] = [
+  {
+    id: "engineering",
+    label: "Engineering",
+    description: "Platform and product delivery",
+    members: "128",
+    status: "Active",
+    children: [
+      {
+        id: "platform",
+        label: "Platform",
+        description: "Shared infrastructure",
+        members: "42",
+        status: "Active",
+        children: [
+          {
+            id: "frontend",
+            label: "Frontend",
+            description: "Web applications",
+            members: "18",
+            status: "Active",
+            children: [
+              {
+                id: "design-system",
+                label: "Design System",
+                description: "Swirl components",
+                members: "7",
+                status: "Active",
+                children: [
+                  {
+                    id: "tokens",
+                    label: "Tokens",
+                    description: "Color, space, type",
+                    members: "2",
+                    status: "Active",
+                  },
+                  {
+                    id: "components",
+                    label: "Components",
+                    description: "Web component library",
+                    members: "4",
+                    status: "Active",
+                    children: [
+                      {
+                        id: "buttons",
+                        label: "Buttons",
+                        description: "Leaf at level 5",
+                        members: "1",
+                        status: "Pending",
+                      },
+                    ],
+                  },
+                  {
+                    id: "icons",
+                    label: "Icons",
+                    description: "Icon set",
+                    members: "1",
+                    status: "Active",
+                  },
+                ],
+              },
+              {
+                id: "web-app",
+                label: "Web App",
+                description: "Closed parent",
+                members: "11",
+                status: "Pending",
+                children: [
+                  {
+                    id: "web-app-core",
+                    label: "Core",
+                    description: "Hidden until expanded",
+                    members: "6",
+                    status: "Active",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: "backend",
+            label: "Backend",
+            description: "Closed parent",
+            members: "16",
+            status: "Active",
+            children: [
+              {
+                id: "api",
+                label: "API",
+                description: "Hidden until expanded",
+                members: "9",
+                status: "Active",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "product",
+        label: "Product",
+        description: "Leaf sibling of Platform",
+        members: "9",
+        status: "Active",
+      },
+    ],
+  },
+  {
+    id: "marketing",
+    label: "Marketing",
+    description: "Closed root",
+    members: "24",
+    status: "Pending",
+    children: [
+      {
+        id: "brand",
+        label: "Brand",
+        description: "Hidden until expanded",
+        members: "6",
+        status: "Active",
+      },
+    ],
+  },
+  {
+    id: "legal",
+    label: "Legal",
+    description: "Leaf at the root",
+    members: "5",
+    status: "Active",
+  },
+];
+
+type FlatTreeRow = TreeNode & {
+  level: number;
+  expandable: boolean;
+  expanded: boolean;
+  setSize: number;
+  posInset: number;
+};
+
+const flattenVisibleTree = (
+  nodes: TreeNode[],
+  expandedIds: Set<string>,
+  level = 0
+): FlatTreeRow[] =>
+  nodes.flatMap((node, index) => {
+    const expandable = Boolean(node.children?.length);
+    const expanded = expandable && expandedIds.has(node.id);
+    const row: FlatTreeRow = {
+      ...node,
+      level,
+      expandable,
+      expanded,
+      setSize: nodes.length,
+      posInset: index + 1,
+    };
+
+    return expanded
+      ? [row, ...flattenVisibleTree(node.children, expandedIds, level + 1)]
+      : [row];
+  });
+
+const collectDescendantIds = (node: TreeNode): string[] =>
+  (node.children ?? []).flatMap((child) => [
+    child.id,
+    ...collectDescendantIds(child),
+  ]);
+
+const findNode = (nodes: TreeNode[], id: string): TreeNode | undefined => {
+  for (const node of nodes) {
+    if (node.id === id) {
+      return node;
+    }
+
+    const match = node.children && findNode(node.children, id);
+
+    if (match) {
+      return match;
+    }
+  }
+
+  return undefined;
+};
+
+const renderTreeRow = (row: FlatTreeRow, withSelection: boolean) => `
+  <swirl-table-row
+    id="${row.id}"
+    tree-level="${row.level}"
+    ${row.expandable ? "tree-expandable" : ""}
+    ${row.expanded ? "tree-expanded" : ""}
+    tree-set-size="${row.setSize}"
+    tree-pos-inset="${row.posInset}"
+  >
+    ${
+      withSelection
+        ? `<swirl-table-cell>
+          <swirl-checkbox swirl-aria-label="Select ${row.label}" input-id="select-${row.id}" input-name="select-${row.id}">
+        </swirl-table-cell>`
+        : ""
+    }
+    <swirl-table-cell
+      tree
+      level="${row.level}"
+      ${row.expandable ? "expandable" : ""}
+      ${row.expanded ? "expanded" : ""}
+      label="${row.label}"
+    >
+      <swirl-stack spacing="0">
+        <swirl-link href="#" label="${row.label}"></swirl-link>
+        <swirl-text color="subdued" size="sm">${row.description}</swirl-text>
+      </swirl-stack>
+    </swirl-table-cell>
+    <swirl-table-cell>
+      <swirl-text size="sm">${row.members}</swirl-text>
+    </swirl-table-cell>
+    <swirl-table-cell>
+      <swirl-tag label="${row.status}" intent="${
+  row.status === "Active" ? "success" : "warning"
+}"></swirl-tag>
+    </swirl-table-cell>
+  </swirl-table-row>
+`;
+
+const createTreeTable = (withSelection: boolean) => {
+  const element = generateStoryElement("swirl-table", {
+    caption: "A hierarchical table rendered as a treegrid.",
+    label: "Groups",
+    tree: true,
+  }) as HTMLSwirlTableElement;
+
+  const expandedIds = new Set([
+    "engineering",
+    "platform",
+    "frontend",
+    "design-system",
+    "components",
+  ]);
+  const selectedIds = new Set<string>();
+
+  const render = () => {
+    const rows = flattenVisibleTree(TREE_NODES, expandedIds);
+
+    element.innerHTML = `
+      <div slot="columns">
+        ${
+          withSelection
+            ? `<swirl-table-column sticky width="58px">
+          <swirl-checkbox swirl-aria-label="Select all" input-id="select-all" input-name="select-all">
+          </swirl-checkbox><swirl-visually-hidden>Select</swirl-visually-hidden>
+        </swirl-table-column>`
+            : ""
+        }
+        <swirl-table-column min-width="280px" sticky>Tree</swirl-table-column>
+        <swirl-table-column min-width="100px">Members</swirl-table-column>
+        <swirl-table-column min-width="120px">Status</swirl-table-column>
+      </div>
+      <div slot="rows">
+        ${rows.map((row) => renderTreeRow(row, withSelection)).join("")}
+      </div>
+    `;
+
+    if (withSelection) {
+      rows.forEach((row) => {
+        const checkbox = element.querySelector(
+          `swirl-checkbox[input-id="select-${row.id}"]`
+        ) as HTMLSwirlCheckboxElement | null;
+
+        if (checkbox) {
+          checkbox.checked = selectedIds.has(row.id);
+        }
+      });
+    }
+  };
+
+  element.addEventListener(
+    "toggle",
+    (event: CustomEvent<{ expanded: boolean }>) => {
+      const row = (event.target as HTMLElement)?.closest("swirl-table-row");
+
+      if (!row?.id) {
+        return;
+      }
+
+      if (event.detail.expanded) {
+        expandedIds.add(row.id);
+      } else {
+        expandedIds.delete(row.id);
+      }
+
+      render();
+    }
+  );
+
+  if (withSelection) {
+    element.addEventListener("valueChange", (event: CustomEvent<boolean>) => {
+      const checkbox = event.target as HTMLSwirlCheckboxElement;
+      const row = checkbox.closest("swirl-table-row");
+      const node = row ? findNode(TREE_NODES, row.id) : undefined;
+
+      if (!node) {
+        return;
+      }
+
+      const ids = [node.id, ...collectDescendantIds(node)];
+
+      ids.forEach((id) => {
+        if (event.detail) {
+          selectedIds.add(id);
+        } else {
+          selectedIds.delete(id);
+        }
+      });
+
+      render();
+    });
+  }
+
+  render();
+
+  return element;
+};
+
+export const TreeView = () => createTreeTable(false);
+
+TreeView.parameters = {
+  docs: {
+    description: {
+      story:
+        "Flat sibling rows with computed indent. The consumer owns expand state and which rows are visible.",
+    },
+  },
+};
+
+export const TreeViewWithSelection = () => createTreeTable(true);
+
+TreeViewWithSelection.parameters = {
+  docs: {
+    description: {
+      story:
+        "Tree cells coexist with row-selection checkboxes. Descendant selection is owned by the consumer, not the table primitive.",
+    },
+  },
+};

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -7,6 +7,9 @@ export default {
       description:
         'CSS selector for the drag handle. Needs to be set when "enableDragDrop" is true. The handle should be a button.',
     },
+    tree: {
+      control: "boolean",
+    },
   },
   component: "swirl-table",
   tags: ["autodocs"],
@@ -399,11 +402,15 @@ const renderTreeRow = (row: FlatTreeRow, withSelection: boolean) => `
   </swirl-table-row>
 `;
 
-const createTreeTable = (withSelection: boolean) => {
+const createTreeTable = (
+  withSelection: boolean,
+  args: Record<string, unknown> = {}
+) => {
   const element = generateStoryElement("swirl-table", {
     caption: "A hierarchical table rendered as a treegrid.",
     label: "Groups",
     tree: true,
+    ...args,
   }) as HTMLSwirlTableElement;
 
   const expandedIds = new Set([
@@ -517,7 +524,17 @@ const createTreeTable = (withSelection: boolean) => {
   return element;
 };
 
-export const TreeView = () => createTreeTable(false);
+const treeViewArgs = {
+  caption: "A hierarchical table rendered as a treegrid.",
+  dragDropHandle: ".drag-handle",
+  enableDragDrop: false,
+  label: "Groups",
+  tree: true,
+};
+
+export const TreeView = (args) => createTreeTable(false, args);
+
+TreeView.args = { ...treeViewArgs };
 
 TreeView.parameters = {
   docs: {
@@ -528,7 +545,9 @@ TreeView.parameters = {
   },
 };
 
-export const TreeViewWithSelection = () => createTreeTable(true);
+export const TreeViewWithSelection = (args) => createTreeTable(true, args);
+
+TreeViewWithSelection.args = { ...treeViewArgs };
 
 TreeViewWithSelection.parameters = {
   docs: {

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -6,9 +6,20 @@ export default {
     dragDropHandle: {
       description:
         'CSS selector for the drag handle. Needs to be set when "enableDragDrop" is true. The handle should be a button.',
+      if: { arg: "tree", truthy: false },
+    },
+    dragDropInstructions: {
+      if: { arg: "tree", truthy: false },
+    },
+    enableDragDrop: {
+      description:
+        "Enables row drag and drop. Hidden when tree mode is on — the two cannot be combined.",
+      if: { arg: "tree", truthy: false },
     },
     tree: {
       control: "boolean",
+      description:
+        "Renders the table as a treegrid. Disables drag and drop while enabled.",
     },
   },
   component: "swirl-table",
@@ -21,11 +32,22 @@ export default {
   title: "Components/SwirlTable",
 };
 
-const Template = (args) => {
-  const element = generateStoryElement(
-    "swirl-table",
-    args
-  ) as HTMLSwirlTableElement;
+const createUserTable = (args) => {
+  const showDrag = Boolean(args.enableDragDrop);
+  const element = generateStoryElement("swirl-table", {
+    ...args,
+    tree: false,
+    enableDragDrop: showDrag,
+  }) as HTMLSwirlTableElement;
+
+  const dragColumn = showDrag
+    ? `<swirl-table-column>Drag</swirl-table-column>`
+    : "";
+  const dragCell = showDrag
+    ? `<swirl-table-cell>
+          <swirl-button class="drag-handle" hide-label icon="<swirl-icon-drag-handle></swirl-icon-drag-handle>" label="Drag" variant="plain"></swirl-button>
+        </swirl-table-cell>`
+    : "";
 
   element.innerHTML = `
     <div slot="columns">
@@ -34,7 +56,7 @@ const Template = (args) => {
         </swirl-checkbox><swirl-visually-hidden>Select</swirl-visually-hidden>
       </swirl-table-column>
       <swirl-table-column min-width="160px" sticky>User</swirl-table-column>
-      <swirl-table-column>Drag</swirl-table-column>
+      ${dragColumn}
       <swirl-table-column min-width="120px">User ID</swirl-table-column>
       <swirl-table-column min-width="200px" sortable sort="descending">Email</swirl-table-column>
       <swirl-table-column>Location</swirl-table-column>
@@ -51,9 +73,7 @@ const Template = (args) => {
         <swirl-table-cell>
           <swirl-text size="sm" weight="medium">Isabel Lakin</swirl-text>
         </swirl-table-cell>
-        <swirl-table-cell>
-          <swirl-button class="drag-handle" hide-label icon="<swirl-icon-drag-handle></swirl-icon-drag-handle>" label="Drag" variant="plain"></swirl-button>
-        </swirl-table-cell>
+        ${dragCell}
         <swirl-table-cell>
           <swirl-text size="sm" truncate>1234567890</swirl-text>
         </swirl-table-cell>
@@ -85,9 +105,7 @@ const Template = (args) => {
           <swirl-table-cell>
             <swirl-text size="sm" weight="medium">Doyle Stoltenberg</swirl-text>
           </swirl-table-cell>
-          <swirl-table-cell>
-            <swirl-button class="drag-handle" hide-label icon="<swirl-icon-drag-handle></swirl-icon-drag-handle>" label="Drag" variant="plain"></swirl-button>
-          </swirl-table-cell>
+          ${dragCell}
           <swirl-table-cell>
             <swirl-text size="sm" truncate>0987654321</swirl-text>
           </swirl-table-cell>
@@ -117,9 +135,7 @@ const Template = (args) => {
           <swirl-table-cell>
             <swirl-text size="sm" weight="medium">Don Conroy</swirl-text>
           </swirl-table-cell>
-          <swirl-table-cell>
-            <swirl-button class="drag-handle" hide-label icon="<swirl-icon-drag-handle></swirl-icon-drag-handle>" label="Drag" variant="plain"></swirl-button>
-          </swirl-table-cell>
+          ${dragCell}
           <swirl-table-cell>
             <swirl-text size="sm" truncate>5432167890</swirl-text>
           </swirl-table-cell>
@@ -146,15 +162,6 @@ const Template = (args) => {
   `;
 
   return element;
-};
-
-export const SwirlTable = Template.bind({});
-
-SwirlTable.args = {
-  caption: "A table displaying data.",
-  dragDropHandle: ".drag-handle",
-  enableDragDrop: true,
-  label: "Table",
 };
 
 type TreeNode = {
@@ -337,6 +344,22 @@ const flattenVisibleTree = (
       : [row];
   });
 
+const flattenAllTree = (nodes: TreeNode[], level = 0): FlatTreeRow[] =>
+  nodes.flatMap((node, index) => {
+    const row: FlatTreeRow = {
+      ...node,
+      level,
+      expandable: Boolean(node.children?.length),
+      expanded: false,
+      setSize: nodes.length,
+      posInset: index + 1,
+    };
+
+    return node.children?.length
+      ? [row, ...flattenAllTree(node.children, level + 1)]
+      : [row];
+  });
+
 const collectDescendantIds = (node: TreeNode): string[] =>
   (node.children ?? []).flatMap((child) => [
     child.id,
@@ -359,14 +382,27 @@ const findNode = (nodes: TreeNode[], id: string): TreeNode | undefined => {
   return undefined;
 };
 
-const renderTreeRow = (row: FlatTreeRow, withSelection: boolean) => `
+const renderTreeRow = (
+  row: FlatTreeRow,
+  options: { tree: boolean; withDrag: boolean; withSelection: boolean }
+) => {
+  const { tree, withDrag, withSelection } = options;
+  const title = row.href
+    ? `<swirl-link href="${row.href}" label="${row.label}"></swirl-link>`
+    : `<swirl-text size="sm">${row.label}</swirl-text>`;
+
+  return `
   <swirl-table-row
     id="${row.id}"
-    tree-level="${row.level}"
+    ${
+      tree
+        ? `tree-level="${row.level}"
     ${row.expandable ? "tree-expandable" : ""}
     ${row.expanded ? "tree-expanded" : ""}
     tree-set-size="${row.setSize}"
-    tree-pos-inset="${row.posInset}"
+    tree-pos-inset="${row.posInset}"`
+        : ""
+    }
   >
     ${
       withSelection
@@ -376,41 +412,54 @@ const renderTreeRow = (row: FlatTreeRow, withSelection: boolean) => `
         : ""
     }
     <swirl-table-cell
-      tree
+      ${
+        tree
+          ? `tree
       level="${row.level}"
       ${row.expandable ? "expandable" : ""}
       ${row.expanded ? "expanded" : ""}
-      label="${row.label}"
+      label="${row.label}"`
+          : ""
+      }
     >
       <swirl-stack spacing="0">
-        ${
-          row.href
-            ? `<swirl-link href="${row.href}" label="${row.label}"></swirl-link>`
-            : `<swirl-text size="sm">${row.label}</swirl-text>`
-        }
+        ${title}
         <swirl-text color="subdued" size="sm">${row.description}</swirl-text>
       </swirl-stack>
     </swirl-table-cell>
+    ${
+      withDrag
+        ? `<swirl-table-cell>
+          <swirl-button class="drag-handle" hide-label icon="<swirl-icon-drag-handle></swirl-icon-drag-handle>" label="Drag" variant="plain"></swirl-button>
+        </swirl-table-cell>`
+        : ""
+    }
     <swirl-table-cell>
       <swirl-text size="sm">${row.members}</swirl-text>
     </swirl-table-cell>
     <swirl-table-cell>
       <swirl-tag label="${row.status}" intent="${
-  row.status === "Active" ? "success" : "warning"
-}"></swirl-tag>
+    row.status === "Active" ? "success" : "warning"
+  }"></swirl-tag>
     </swirl-table-cell>
   </swirl-table-row>
 `;
+};
 
 const createTreeTable = (
   withSelection: boolean,
   args: Record<string, unknown> = {}
 ) => {
+  const isTree = args.tree !== false;
+  const enableDragDrop = !isTree && Boolean(args.enableDragDrop);
   const element = generateStoryElement("swirl-table", {
-    caption: "A hierarchical table rendered as a treegrid.",
+    caption: isTree
+      ? "A hierarchical table rendered as a treegrid."
+      : "A flat table of the same groups.",
     label: "Groups",
-    tree: true,
     ...args,
+    tree: isTree,
+    enableDragDrop,
   }) as HTMLSwirlTableElement;
 
   const expandedIds = new Set([
@@ -433,7 +482,14 @@ const createTreeTable = (
       </swirl-table-column>`
           : ""
       }
-      <swirl-table-column min-width="360px" sticky>Tree</swirl-table-column>
+      <swirl-table-column min-width="360px" sticky>${
+        isTree ? "Tree" : "Group"
+      }</swirl-table-column>
+      ${
+        enableDragDrop
+          ? `<swirl-table-column>Drag</swirl-table-column>`
+          : ""
+      }
       <swirl-table-column min-width="100px">Members</swirl-table-column>
       <swirl-table-column min-width="120px">Status</swirl-table-column>
     </div>
@@ -463,10 +519,18 @@ const createTreeTable = (
   };
 
   const renderRows = () => {
-    const rows = flattenVisibleTree(TREE_NODES, expandedIds);
+    const rows = isTree
+      ? flattenVisibleTree(TREE_NODES, expandedIds)
+      : flattenAllTree(TREE_NODES);
 
     rowsContainer.innerHTML = rows
-      .map((row) => renderTreeRow(row, withSelection))
+      .map((row) =>
+        renderTreeRow(row, {
+          tree: isTree,
+          withDrag: enableDragDrop,
+          withSelection,
+        })
+      )
       .join("");
 
     applySelection();
@@ -522,6 +586,21 @@ const createTreeTable = (
   renderRows();
 
   return element;
+};
+
+const Template = (args) =>
+  args.tree
+    ? createTreeTable(true, { ...args, enableDragDrop: false })
+    : createUserTable(args);
+
+export const SwirlTable = Template.bind({});
+
+SwirlTable.args = {
+  caption: "A table displaying data.",
+  dragDropHandle: ".drag-handle",
+  enableDragDrop: true,
+  label: "Table",
+  tree: false,
 };
 
 const treeViewArgs = {
@@ -590,6 +669,19 @@ export const TreeViewLabelVariants = () => {
   `;
 
   return element;
+};
+
+TreeViewLabelVariants.args = {
+  caption: "Clickable and plain tree titles.",
+  label: "Tree label variants",
+  tree: true,
+};
+
+TreeViewLabelVariants.argTypes = {
+  dragDropHandle: { control: false, table: { disable: true } },
+  dragDropInstructions: { control: false, table: { disable: true } },
+  enableDragDrop: { control: false, table: { disable: true } },
+  tree: { control: false, table: { disable: true } },
 };
 
 TreeViewLabelVariants.parameters = {

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -619,6 +619,7 @@ export const SwirlTable = Template.bind({});
 SwirlTable.args = {
   caption: "A table displaying data.",
   label: "Table",
+  emptyStateLabel: "No results found.",
   tree: false,
   enableDragDrop: true,
   dragDropHandle: ".drag-handle",
@@ -627,6 +628,7 @@ SwirlTable.args = {
 const treeViewArgs = {
   caption: "A hierarchical table rendered as a treegrid.",
   label: "Groups",
+  emptyStateLabel: "No results found.",
   tree: true,
   enableDragDrop: false,
   dragDropHandle: ".drag-handle",

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.stories.ts
@@ -400,40 +400,55 @@ const createTreeTable = (withSelection: boolean) => {
     "components",
   ]);
   const selectedIds = new Set<string>();
+  let applyingSelection = false;
 
-  const render = () => {
+  element.innerHTML = `
+    <div slot="columns">
+      ${
+        withSelection
+          ? `<swirl-table-column sticky width="58px">
+        <swirl-checkbox swirl-aria-label="Select all" input-id="select-all" input-name="select-all">
+        </swirl-checkbox><swirl-visually-hidden>Select</swirl-visually-hidden>
+      </swirl-table-column>`
+          : ""
+      }
+      <swirl-table-column min-width="280px" sticky>Tree</swirl-table-column>
+      <swirl-table-column min-width="100px">Members</swirl-table-column>
+      <swirl-table-column min-width="120px">Status</swirl-table-column>
+    </div>
+    <div slot="rows"></div>
+  `;
+
+  const rowsContainer = element.querySelector('[slot="rows"]') as HTMLElement;
+
+  const applySelection = () => {
+    if (!withSelection) {
+      return;
+    }
+
+    applyingSelection = true;
+
+    element.querySelectorAll("swirl-checkbox").forEach((checkbox) => {
+      const row = checkbox.closest("swirl-table-row");
+
+      if (row) {
+        (checkbox as HTMLSwirlCheckboxElement).checked = selectedIds.has(
+          row.id
+        );
+      }
+    });
+
+    applyingSelection = false;
+  };
+
+  const renderRows = () => {
     const rows = flattenVisibleTree(TREE_NODES, expandedIds);
 
-    element.innerHTML = `
-      <div slot="columns">
-        ${
-          withSelection
-            ? `<swirl-table-column sticky width="58px">
-          <swirl-checkbox swirl-aria-label="Select all" input-id="select-all" input-name="select-all">
-          </swirl-checkbox><swirl-visually-hidden>Select</swirl-visually-hidden>
-        </swirl-table-column>`
-            : ""
-        }
-        <swirl-table-column min-width="280px" sticky>Tree</swirl-table-column>
-        <swirl-table-column min-width="100px">Members</swirl-table-column>
-        <swirl-table-column min-width="120px">Status</swirl-table-column>
-      </div>
-      <div slot="rows">
-        ${rows.map((row) => renderTreeRow(row, withSelection)).join("")}
-      </div>
-    `;
+    rowsContainer.innerHTML = rows
+      .map((row) => renderTreeRow(row, withSelection))
+      .join("");
 
-    if (withSelection) {
-      rows.forEach((row) => {
-        const checkbox = element.querySelector(
-          `swirl-checkbox[input-id="select-${row.id}"]`
-        ) as HTMLSwirlCheckboxElement | null;
-
-        if (checkbox) {
-          checkbox.checked = selectedIds.has(row.id);
-        }
-      });
-    }
+    applySelection();
   };
 
   element.addEventListener(
@@ -451,12 +466,16 @@ const createTreeTable = (withSelection: boolean) => {
         expandedIds.delete(row.id);
       }
 
-      render();
+      renderRows();
     }
   );
 
   if (withSelection) {
     element.addEventListener("valueChange", (event: CustomEvent<boolean>) => {
+      if (applyingSelection) {
+        return;
+      }
+
       const checkbox = event.target as HTMLSwirlCheckboxElement;
       const row = checkbox.closest("swirl-table-row");
       const node = row ? findNode(TREE_NODES, row.id) : undefined;
@@ -475,11 +494,11 @@ const createTreeTable = (withSelection: boolean) => {
         }
       });
 
-      render();
+      applySelection();
     });
   }
 
-  render();
+  renderRows();
 
   return element;
 };

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.tsx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.tsx
@@ -53,13 +53,17 @@ export class SwirlTable {
   @Prop() dragDropHandle?: string;
   @Prop() dragDropInstructions = defaultDragDropInstructions;
   @Prop() emptyStateLabel?: string = "No results found.";
+  /**
+   * Enables row drag and drop. Ignored when the table is in tree mode —
+   * combining hierarchy with reorder is not supported.
+   */
   @Prop() enableDragDrop?: boolean;
   @Prop() label!: string;
   @Prop() loading?: boolean;
   /**
    * Enables treegrid semantics (`role="treegrid"`). Use with tree props on
    * `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell
-   * has the `tree` attribute.
+   * has the `tree` attribute. Incompatible with `enableDragDrop`.
    */
   @Prop() tree?: boolean = false;
 
@@ -81,6 +85,7 @@ export class SwirlTable {
   private positionBeforeKeyboardMove?: number;
   private rowMutationObserver: MutationObserver;
   private sortable: Sortable | undefined;
+  private warnedTreeDragDrop = false;
 
   async componentDidLoad() {
     this.setupIntersectionObserver();
@@ -99,6 +104,7 @@ export class SwirlTable {
   }
 
   @Watch("enableDragDrop")
+  @Watch("tree")
   handleEnableDragDropChange() {
     queueMicrotask(() => {
       this.setupDragDrop();
@@ -173,7 +179,17 @@ export class SwirlTable {
       this.sortable = undefined;
     }
 
-    if (this.enableDragDrop) {
+    if (this.enableDragDrop && this.isTreeGrid()) {
+      if (!this.warnedTreeDragDrop) {
+        console.warn(
+          "[Swirl] Drag & drop is not supported when swirl-table is in tree mode."
+        );
+        this.warnedTreeDragDrop = true;
+      }
+      return;
+    }
+
+    if (this.isDragDropEnabled()) {
       const tableHasRowGroups = !!this.el.querySelector(
         "swirl-table-row-group"
       );
@@ -563,6 +579,10 @@ export class SwirlTable {
     );
   }
 
+  private isDragDropEnabled() {
+    return Boolean(this.enableDragDrop) && !this.isTreeGrid();
+  }
+
   private updateLiveRegionText(
     key?: keyof typeof this.dragDropInstructions,
     data: { position?: number; rowCount?: number } = {}
@@ -744,7 +764,7 @@ export class SwirlTable {
   };
 
   private onKeyDown = (event: KeyboardEvent) => {
-    if (!this.enableDragDrop) {
+    if (!this.isDragDropEnabled()) {
       return;
     }
 
@@ -793,7 +813,7 @@ export class SwirlTable {
     return (
       <Host>
         <div class={className}>
-          {this.enableDragDrop && (
+          {this.isDragDropEnabled() && (
             <swirl-visually-hidden>
               <span aria-live="assertive">{this.liveRegionText}</span>
             </swirl-visually-hidden>

--- a/packages/swirl-components/src/components/swirl-table/swirl-table.tsx
+++ b/packages/swirl-components/src/components/swirl-table/swirl-table.tsx
@@ -56,6 +56,12 @@ export class SwirlTable {
   @Prop() enableDragDrop?: boolean;
   @Prop() label!: string;
   @Prop() loading?: boolean;
+  /**
+   * Enables treegrid semantics (`role="treegrid"`). Use with tree props on
+   * `swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell
+   * has the `tree` attribute.
+   */
+  @Prop() tree?: boolean = false;
 
   @Event() dropRow: EventEmitter<SwirlTableDropRowEvent>;
 
@@ -551,6 +557,12 @@ export class SwirlTable {
     this.empty = !Boolean(rowsContainer) || rowsContainer.children.length === 0;
   }
 
+  private isTreeGrid() {
+    return (
+      this.tree || Boolean(this.el.querySelector("swirl-table-cell[tree]"))
+    );
+  }
+
   private updateLiveRegionText(
     key?: keyof typeof this.dragDropInstructions,
     data: { position?: number; rowCount?: number } = {}
@@ -799,7 +811,7 @@ export class SwirlTable {
             <div
               aria-describedby={Boolean(this.caption) ? "caption" : undefined}
               aria-label={this.label}
-              role="table"
+              role={this.isTreeGrid() ? "treegrid" : "table"}
               class="table__table"
             >
               {this.caption && (

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -25860,7 +25860,7 @@
         },
         {
           "name": "enable-drag-drop",
-          "description": ""
+          "description": "Enables row drag and drop. Ignored when the table is in tree mode —\ncombining hierarchy with reorder is not supported."
         },
         {
           "name": "label",
@@ -25872,7 +25872,7 @@
         },
         {
           "name": "tree",
-          "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute."
+          "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute. Incompatible with `enableDragDrop`."
         }
       ]
     },

--- a/packages/swirl-components/vscode-data.json
+++ b/packages/swirl-components/vscode-data.json
@@ -25869,6 +25869,10 @@
         {
           "name": "loading",
           "description": ""
+        },
+        {
+          "name": "tree",
+          "description": "Enables treegrid semantics (`role=\"treegrid\"`). Use with tree props on\n`swirl-table-row` / `swirl-table-cell`. Also inferred when a slotted cell\nhas the `tree` attribute."
         }
       ]
     },
@@ -25878,7 +25882,36 @@
         "kind": "markdown",
         "value": ""
       },
-      "attributes": []
+      "attributes": [
+        {
+          "name": "collapsed-icon",
+          "description": "Glyph override for the collapsed toggle. Defaults to `chevron-right`."
+        },
+        {
+          "name": "expandable",
+          "description": "When true, the cell has children and renders a toggle. When false, it is a\nleaf and content sits flush after the level indent (no toggle zone)."
+        },
+        {
+          "name": "expanded",
+          "description": "Open/closed state. Controlled by the consumer; ignored when not expandable."
+        },
+        {
+          "name": "expanded-icon",
+          "description": "Glyph override for the expanded toggle. Defaults to `expand-more`."
+        },
+        {
+          "name": "label",
+          "description": "Accessible name of the tree node, used to build the toggle label\n(`Expand {label}` / `Collapse {label}`)."
+        },
+        {
+          "name": "level",
+          "description": "0-indexed depth. Drives computed inline-start indent when `tree` is true."
+        },
+        {
+          "name": "tree",
+          "description": "Enable the tree affordance (indent + optional expand/collapse toggle)."
+        }
+      ]
     },
     {
       "name": "swirl-table-column",
@@ -25950,6 +25983,26 @@
         {
           "name": "index",
           "description": ""
+        },
+        {
+          "name": "tree-expandable",
+          "description": "Whether this row has children. When true, `aria-expanded` is set from\n`treeExpanded`."
+        },
+        {
+          "name": "tree-expanded",
+          "description": "Whether this expandable row is currently expanded. Ignored when not\nexpandable."
+        },
+        {
+          "name": "tree-level",
+          "description": "0-indexed tree depth. Mapped to 1-based `aria-level` for treegrid."
+        },
+        {
+          "name": "tree-pos-inset",
+          "description": "1-based position among siblings. Mapped to `aria-posinset`."
+        },
+        {
+          "name": "tree-set-size",
+          "description": "Number of siblings at this level. Mapped to `aria-setsize`."
         }
       ]
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- [Ticket](https://linear.app/flip/issue/SWR-147/add-tree-view-to-the-table)
- [Storybook](https://swirl-storybook.flip-app.dev/?path=/docs/components-swirltable--docs)

Adds a **generic** tree affordance to the `swirl-table` family so consumers can expand/collapse hierarchical rows in place.

### Tree toggle

- Plain `swirl-button` (no ghost hover fill).
- 8px (`space-8`) between the toggle and the label.
- Child-row indent is `24px + 8px` so leaves still line up with the parent label.

[Plain tree toggle with 8px gap before the label](https://cursor.com/agents/bc-32b0faa3-318f-4b52-a0a0-1f5fd1a97665/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftree_toggle_plain_gap.webp)
[Tree row collapsed with the plain toggle](https://cursor.com/agents/bc-32b0faa3-318f-4b52-a0a0-1f5fd1a97665/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftree_toggle_collapsed.webp)

[tree_toggle_plain_gap_verified.mp4](https://cursor.com/agents/bc-32b0faa3-318f-4b52-a0a0-1f5fd1a97665/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftree_toggle_plain_gap_verified.mp4)

### Storybook controls

`tree` and `enableDragDrop` change the canvas. Docs PROPERTIES order is `caption`, `label`, `emptyStateLabel`, `tree`, then drag-and-drop props, then `loading`. Drag-and-drop controls stay hidden while tree is on.

The primitive is presentational and controlled.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SWR-147](https://linear.app/flip/issue/SWR-147/add-tree-view-to-the-table)

<div><a href="https://cursor.com/agents/bc-32b0faa3-318f-4b52-a0a0-1f5fd1a97665?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32b0faa3-318f-4b52-a0a0-1f5fd1a97665&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

